### PR TITLE
静的Metadataと動的Metadataの構築検証

### DIFF
--- a/src/app/app-router/dashboard/layout.tsx
+++ b/src/app/app-router/dashboard/layout.tsx
@@ -1,0 +1,7 @@
+export default function DashboardLayout({
+  children,
+}: {
+  children: React.ReactNode
+}) {
+  return <section>{children}</section>
+}

--- a/src/app/app-router/dashboard/page.tsx
+++ b/src/app/app-router/dashboard/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next'
+
+// metaデータの上書き
+// only server component
+export const metadata: Metadata = {
+  title: 'dashboard page',
+}
+
+export default function DashboardPage() {
+  return <h1>ダッシュボードです</h1>
+}

--- a/src/app/app-router/job_offers/[id]/page.tsx
+++ b/src/app/app-router/job_offers/[id]/page.tsx
@@ -1,0 +1,71 @@
+import { cpSync } from 'fs';
+import { Metadata, ResolvingMetadata } from 'next'
+
+type Props = {
+  params: { id: string }
+  searchParams: { [key: string]: string | string[] | undefined }
+}
+
+// 動的なmetaデータの上書き
+// only server component
+export async function generateMetadata(
+  { params, searchParams }: Props,
+  parent: ResolvingMetadata
+): Promise<Metadata> {
+
+  const res = await fetch(
+    `https://jsonplaceholder.typicode.com/posts/${params.id}`
+  );
+  const data = (await res.json());
+
+  // こんなイメージで、画像のパスが格納されているDBからデータもってきて、URLを差し込む
+  // const jobOfferData = await fetch('https://example.com/job_offers/1').then(
+  //   async (res) => await res.json()
+  // );
+
+  const jobOfferData = {
+    url: 'https://via.placeholder.com/200x100',
+    title: '聖光病院急募〜未経験可〜',
+    alt: '聖光病院'
+  }
+
+  return {
+    title: `${data.id}: ${jobOfferData.title}`,
+    description: `ディスクリプション:${data.id} ${data.body}`,
+    openGraph: {
+      title: `${data.id}: ${jobOfferData.title}`,
+      description: `ディスクリプション:${data.id} ${data.body}`,
+      images: [
+        {
+          url: jobOfferData.url,
+          width: 1200,
+          height: 630,
+          alt: jobOfferData.alt
+        },
+      ],
+    },
+  };
+
+  //
+  // Sample Code.
+  //
+  // // read route params
+  // const id = params.id
+
+  // // fetch data
+  // const product = await fetch(`https://.../${id}`).then((res) => res.json())
+
+  // // optionally access and extend (rather than replace) parent metadata
+  // const previousImages = (await parent).openGraph?.images || []
+
+  // return {
+  //   title: product.title,
+  //   openGraph: {
+  //     images: ['/some-specific-page-image.jpg', ...previousImages],
+  //   },
+  // }
+}
+
+export default function JobOfferDetailPage({ params, searchParams }: Props) {
+  return <h1>求人詳細です</h1>
+}

--- a/src/app/app-router/job_offers/page.tsx
+++ b/src/app/app-router/job_offers/page.tsx
@@ -1,0 +1,11 @@
+import { Metadata } from 'next'
+
+// metaデータの上書き
+// only server component
+export const metadata: Metadata = {
+  title: 'job_offer page',
+}
+
+export default function JobOfferPage() {
+  return <h1>求人一覧です</h1>
+}

--- a/src/app/app-router/page.tsx
+++ b/src/app/app-router/page.tsx
@@ -1,3 +1,12 @@
+import { Metadata } from 'next'
+
+// metaデータの上書き
+// only server component
+export const metadata: Metadata = {
+  title: 'app-router page',
+  metadataBase: new URL('https://acme.com'),
+}
+
 export default function Page() {
   return <h1>App Routerで動くページ</h1>
 }


### PR DESCRIPTION
## Conclusion
- 静的なメタ情報はmetadata
- 動的なメタ情報はgenerateMetadata
- この設定ができるのはServer Components のみ
- page.tsx or layout.tsx のみに定義可能
- Vercel以外のホスティングサービスを利用する場合はmetadataBaseを設定する必要があるらしい。
  -  何も設定しないと、デプロイしたにも関わらずlocalhostになるらしい
  - ref. https://nextjs.org/docs/app/api-reference/functions/generate-metadata#default-value

## Think about it later
- 全体の構成
- トップはどんなものをデフォルトで書いておくか
- 子ページ側で効率的にどう上書きしていくか
  - pageに愚直に書くのではなく、なにか仕組み化できないか