### PR TITLE
Errorハンドリングの検証

### DIFF
--- a/src/app/app-router/error/app-error/page.tsx
+++ b/src/app/app-router/error/app-error/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from 'next'
+import Link from 'next/link'
+
+// metaデータの上書き
+// only server component
+export const metadata: Metadata = {
+  title: 'app error page',
+  metadataBase: new URL('https://acme.com'),
+}
+
+export default function GlobalError() {
+  throw '何かしらのエラー、Rootにある、error.tsxでハンドリング';
+  return (
+    <>
+      <h1>ここには到達しない予定のページ</h1>
+      <Link href="/app-router">app-routerページへ</Link>
+    </>
+  )
+}

--- a/src/app/app-router/error/handle-error/error.tsx
+++ b/src/app/app-router/error/handle-error/error.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+export default function HandleError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  console.log(error);
+  return (
+    <div>
+      <h2>Something went wrong!(Handle Error)</h2>
+      <button onClick={() => reset()}>Try again</button>
+    </div>
+  )
+}

--- a/src/app/app-router/error/handle-error/page.tsx
+++ b/src/app/app-router/error/handle-error/page.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from 'next'
+import Link from 'next/link'
+
+// metaデータの上書き
+// only server component
+export const metadata: Metadata = {
+  title: 'handle error page',
+  metadataBase: new URL('https://acme.com'),
+}
+
+export default function HandleError() {
+  // throw '何かしらのエラー、error.tsxでハンドリング';
+  return (
+    <>
+      <h1>ここには到達しない予定のページ</h1>
+      <Link href="/app-router">app-routerページへ</Link>
+    </>
+  )
+}

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+export default function AppError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  console.log(`AppError: ${error}`);
+
+  return (
+    <html>
+      <body>
+        <h2>Something went wrong!(App Error)</h2>
+        <button onClick={() => reset()}>Try again</button>
+      </body>
+    </html>
+  )
+}

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+export default function GlobalError({
+  error,
+  reset,
+}: {
+  error: Error & { digest?: string }
+  reset: () => void
+}) {
+  console.log(`GlobalError: ${error}`);
+
+  return (
+    <html>
+      <body>
+        <h2>Something went wrong!(Global Error)</h2>
+        <button onClick={() => reset()}>Try again</button>
+      </body>
+    </html>
+  )
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -15,6 +15,7 @@ export default function RootLayout({
 }: {
   children: React.ReactNode
 }) {
+  // throw '何かしらのエラー、このlayoutレベルで発生するエラーは、global-error.tsxでハンドリング';
   return (
     <html lang="en">
       <body className={inter.className}>


### PR DESCRIPTION
## Conclusion
- layout等の考えと同様で、それぞれにerror.tsxを配置することで意図しなかったエラーを捕捉できる
- 事前に設計して、このページは別のものを出したいとかであればそのディレクトリに作ればいい
- app直下のlayout.jsとtemplate.jsに関しては、error-global.tsxを使って捕捉する必要がある
  - https://github.com/vercel/next.js/issues/55462