### PR TITLE
Next関連モジュールのラップ作成検証 + ESLintでNext関連のモジュールの使用不可検証 + TS周りのエラー修正

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,16 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    // NOTE: WrapしたNextのものはそっちを使って欲しい意図で、
+    //       厳しい制約を付与
+    //       0 = off, 1 = warn, 2 = error
+    "react/forbid-elements": [2, {
+      "forbid": [
+        {
+          "element": "Link",
+          "message": "use <WrapLink> element instead"
+        }
+      ]
+    }]
+  }
 }

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "autoprefixer": "^10.0.1",
     "eslint": "^8",
     "eslint-config-next": "14.0.4",
+    "eslint-plugin-react": "^7.33.2",
     "msw": "^2.1.5",
     "orval": "^6.23.0",
     "postcss": "^8",

--- a/src/app/app-router/dashboard/page.tsx
+++ b/src/app/app-router/dashboard/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next'
-import Link from 'next/link'
+import { WrapLink } from '@/components/WrapLink'
 
 // metaデータの上書き
 // only server component
@@ -11,7 +11,7 @@ export default function DashboardPage() {
   return (
     <>
       <h1>ダッシュボードです</h1>
-      <Link href="/app-router/job_offers">求人一覧ページへ</Link>
+      <WrapLink href="/app-router/job_offers">求人一覧ページへ</WrapLink>
     </>
   )
 }

--- a/src/app/app-router/error/app-error/page.tsx
+++ b/src/app/app-router/error/app-error/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next'
-import Link from 'next/link'
+import { WrapLink } from '@/components/WrapLink'
 
 // metaデータの上書き
 // only server component
@@ -13,7 +13,7 @@ export default function GlobalError() {
   return (
     <>
       <h1>ここには到達しない予定のページ</h1>
-      <Link href="/app-router">app-routerページへ</Link>
+      <WrapLink href="/app-router">app-routerページへ</WrapLink>
     </>
   )
 }

--- a/src/app/app-router/error/handle-error/page.tsx
+++ b/src/app/app-router/error/handle-error/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next'
-import Link from 'next/link'
+import { WrapLink } from '@/components/WrapLink'
 
 // metaデータの上書き
 // only server component
@@ -13,7 +13,7 @@ export default function HandleError() {
   return (
     <>
       <h1>ここには到達しない予定のページ</h1>
-      <Link href="/app-router">app-routerページへ</Link>
+      <WrapLink href="/app-router">app-routerページへ</WrapLink>
     </>
   )
 }

--- a/src/app/app-router/job_offers/page.tsx
+++ b/src/app/app-router/job_offers/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next'
-import Link from 'next/link'
+import { WrapLink } from '@/components/WrapLink'
 
 // metaデータの上書き
 // only server component
@@ -29,7 +29,7 @@ export default function JobOfferPage() {
       {
         jobOffers.map((jobOffer) => (
           <div key={jobOffer.id}>
-            <Link href={`/app-router/job_offers/${jobOffer.id}`}>{`求人詳細: ${jobOffer.title}のページへ`}</Link>
+            <WrapLink href={`/app-router/job_offers/${jobOffer.id}`}>{`求人詳細: ${jobOffer.title}のページへ`}</WrapLink>
           </div>
         ))
       }

--- a/src/app/app-router/page.tsx
+++ b/src/app/app-router/page.tsx
@@ -1,5 +1,5 @@
 import { Metadata } from 'next'
-import Link from 'next/link'
+import { WrapLink } from '@/components/WrapLink'
 
 // metaデータの上書き
 // only server component
@@ -12,7 +12,7 @@ export default function Page() {
   return (
     <>
       <h1>App Routerで動くページ</h1>
-      <Link href="/app-router/dashboard">Dashboardページへ</Link>
+      <WrapLink href="/app-router/dashboard">Dashboardページへ</WrapLink>
     </>
   )
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,11 @@
 import Image from 'next/image'
-import Link from 'next/link'
+import { WrapLink } from '@/components/WrapLink'
 
 export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-between p-24">
-      <Link href="/app-router/">AppRouterで構築されたページへ</Link>
-      <Link href="/pages-router/">PagesRouterで構築されたページへ</Link>
+      <WrapLink href="/app-router/">AppRouterで構築されたページへ</WrapLink>
+      <WrapLink href="/pages-router/">PagesRouterで構築されたページへ</WrapLink>
       <div className="z-10 max-w-5xl w-full items-center justify-between font-mono text-sm lg:flex">
         <p className="fixed left-0 top-0 flex w-full justify-center border-b border-gray-300 bg-gradient-to-b from-zinc-200 pb-6 pt-8 backdrop-blur-2xl dark:border-neutral-800 dark:bg-zinc-800/30 dark:from-inherit lg:static lg:w-auto  lg:rounded-xl lg:border lg:bg-gray-200 lg:p-4 lg:dark:bg-zinc-800/30">
           Get started by editing&nbsp;

--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -1,18 +1,18 @@
 'use client'
 
-import { usePathname } from 'next/navigation'
-import Link from "next/link"
+import { useNavigationPathname } from '@/hooks/useNavigation'
+import { WrapLink } from '@/components/WrapLink'
 import { Input } from "@/components/ui/input"
 
 export default function Header() {
-  const pathname = usePathname();
+  const pathname = useNavigationPathname();
 
   return (
     <header className="flex items-center justify-between px-4 py-2 bg-white dark:bg-gray-800">
-      <Link href="#">
+      <WrapLink href="#">
         <BriefcaseIcon className="h-6 w-6" />
         <span className="sr-only">JobSite</span>
-      </Link>
+      </WrapLink>
       <div className="flex-1 mx-4">
         <Input
           className="w-full px-3 py-2 border border-gray-300 rounded-md"
@@ -21,28 +21,28 @@ export default function Header() {
         />
       </div>
       <nav className="flex items-center space-x-4">
-        <Link
+        <WrapLink
           className={`${pathname === '/app-router' ? 'bg-sky-100 text-blue-600' : ''}text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100`} href="/app-router">
           Home
-        </Link>
-        <Link className={`${pathname === '/app-router/job_offers' ? 'bg-sky-100 text-blue-600' : ''}text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100`} href="/app-router/job_offers">
+        </WrapLink>
+        <WrapLink className={`${pathname === '/app-router/job_offers' ? 'bg-sky-100 text-blue-600' : ''}text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100`} href="/app-router/job_offers">
           Jobs
-        </Link>
-        <Link className={`${pathname === '/app-router/dashboard' ? 'bg-sky-100 text-blue-600' : ''}text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100`} href="/app-router/dashboard">
+        </WrapLink>
+        <WrapLink className={`${pathname === '/app-router/dashboard' ? 'bg-sky-100 text-blue-600' : ''}text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100`} href="/app-router/dashboard">
           Dashboard
-        </Link>
-        <Link className={`${pathname === '/app-router/about' ? 'bg-sky-100 text-blue-600' : ''}text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100`} href="#">
+        </WrapLink>
+        <WrapLink className={`${pathname === '/app-router/about' ? 'bg-sky-100 text-blue-600' : ''}text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100`} href="#">
           About
-        </Link>
-        <Link className={`${pathname === '/app-router/contact' ? 'bg-sky-100 text-blue-600' : ''}text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100`} href="#">
+        </WrapLink>
+        <WrapLink className={`${pathname === '/app-router/contact' ? 'bg-sky-100 text-blue-600' : ''}text-gray-700 hover:text-gray-900 dark:text-gray-300 dark:hover:text-gray-100`} href="#">
           Contact
-        </Link>
+        </WrapLink>
       </nav>
     </header>
   )
 }
 
-function BriefcaseIcon(props) {
+function BriefcaseIcon(props: JSX.IntrinsicElements['svg']) {
   return (
     <svg
       {...props}

--- a/src/components/WrapLink/index.tsx
+++ b/src/components/WrapLink/index.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link"
+
+const WrapLink = ({
+  href, className, children
+}: {
+  href: string;
+  className?: string;
+  children: React.ReactNode;
+}) => {
+  return (
+    // TODO: disable以外に何か方法ありそうと思っている
+    // eslint-disable-next-line react/forbid-elements
+    <Link href={href} className={className}>
+      {children}
+    </Link>
+  )
+}
+
+export {
+  WrapLink,
+}

--- a/src/hooks/useNavigation.ts
+++ b/src/hooks/useNavigation.ts
@@ -1,0 +1,10 @@
+import { usePathname } from 'next/navigation';
+
+const useNavigationPathname = () => {
+  const pathname = usePathname();
+  return pathname;
+}
+
+export {
+  useNavigationPathname,
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
-    "module": "esnext",
+    "module": "Nodenext",
     "moduleResolution": "Nodenext",
     "resolveJsonModule": true,
     "isolatedModules": true,


### PR DESCRIPTION
## Conclusion
- next/link や next/navigation, next/imgなどをwrapする
- nextモジュールの呼び出しを禁止するために、 `react/forbid-elements` を使ってみる
  - https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md

## Other
- ラップした場所のルールの適用の外し方他に方法ないか（いまはdisabled）
- ラップしたコンポーネント置き場に困っている
- hooksに関しては、src直下のhooks配下で管理すればいいイメージ 