### PR TITLE
フロントのコード自動生成周りを今まで踏まえて全体的に設計し直したもの

### DIFF
--- a/openapi/web-practice-tech/openapi.yaml
+++ b/openapi/web-practice-tech/openapi.yaml
@@ -29,7 +29,44 @@ paths:
       summary: すべての投稿を返却する
       tags:
       - Posts
+    post:
+      description: N/A
+      operationId: createPost
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreatePostRequestBody'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatePostResponseBody'
+          description: Successful response
+      summary: 投稿を登録する
+      tags:
+      - Users
   /posts/{postId}:
+    delete:
+      description: N/A
+      operationId: deletePost
+      parameters:
+      - in: path
+        name: postId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeletePostResponseBody'
+          description: Successful response
+      summary: 指定されたIDの投稿を削除する.
+      tags:
+      - Posts
     get:
       description: N/A
       operationId: getPostDetail
@@ -47,6 +84,30 @@ paths:
                 $ref: '#/components/schemas/PostResponseBody'
           description: Successful response
       summary: 指定されたIDの投稿を取得する.
+      tags:
+      - Posts
+    put:
+      description: N/A
+      operationId: updatePost
+      parameters:
+      - in: path
+        name: postId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdatePostRequestBody'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdatePostResponseBody'
+          description: Successful response
+      summary: 指定されたIDの投稿を更新する.
       tags:
       - Posts
   /posts/{postId}/comments:
@@ -86,7 +147,44 @@ paths:
       summary: すべてのユーザを返却する
       tags:
       - Users
+    post:
+      description: N/A
+      operationId: createUser
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateUserRequestBody'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateUserResponseBody'
+          description: Successful response
+      summary: ユーザを登録する
+      tags:
+      - Users
   /users/{userId}:
+    delete:
+      description: N/A
+      operationId: deleteUser
+      parameters:
+      - in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteUserResponseBody'
+          description: Successful response
+      summary: 指定されたIDのユーザを削除する.
+      tags:
+      - Users
     get:
       description: N/A
       operationId: getUserDetail
@@ -104,6 +202,30 @@ paths:
                 $ref: '#/components/schemas/UserResponseBody'
           description: Successful response
       summary: 指定されたIDのユーザを取得する.
+      tags:
+      - Users
+    put:
+      description: N/A
+      operationId: updateUser
+      parameters:
+      - in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateUserRequestBody'
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpdateUserResponseBody'
+          description: Successful response
+      summary: 指定されたIDのユーザを更新する.
       tags:
       - Users
   /users/{userId}/comments:
@@ -132,6 +254,26 @@ components:
       items:
         $ref: '#/components/schemas/post'
       type: array
+    CreatePostResponseBody:
+      items:
+        $ref: '#/components/schemas/post'
+      type: array
+    CreatePostRequestBody:
+      example:
+        id: 0
+        completed: completed
+        title: title
+        userId: 6
+      properties:
+        id:
+          type: integer
+        userId:
+          type: integer
+        title:
+          type: string
+        completed:
+          type: string
+      type: object
     PostResponseBody:
       $ref: '#/components/schemas/post'
     post:
@@ -155,6 +297,29 @@ components:
       - title
       - userId
       type: object
+    UpdatePostResponseBody:
+      items:
+        $ref: '#/components/schemas/post'
+      type: array
+    UpdatePostRequestBody:
+      example:
+        id: 0
+        completed: completed
+        title: title
+        userId: 6
+      properties:
+        id:
+          type: integer
+        userId:
+          type: integer
+        title:
+          type: string
+        completed:
+          type: string
+      type: object
+    DeletePostResponseBody:
+      properties: {}
+      type: object
     PostDetailCommentListResponseBody:
       items:
         $ref: '#/components/schemas/PostDetailCommentListResponseBody_inner'
@@ -163,6 +328,50 @@ components:
       items:
         $ref: '#/components/schemas/user'
       type: array
+    CreateUserResponseBody:
+      items:
+        $ref: '#/components/schemas/user'
+      type: array
+    CreateUserRequestBody:
+      example:
+        website: website
+        address:
+          zipcode: zipcode
+          geo:
+            lon: lon
+            lat: lat
+          suite: suite
+          city: city
+          street: street
+        phone: phone
+        name: name
+        company:
+          bs: bs
+          catchPhrase: catchPhrase
+          name: name
+        email: email
+        username: username
+      properties:
+        name:
+          nullable: true
+          type: string
+        username:
+          nullable: true
+          type: string
+        email:
+          nullable: true
+          type: string
+        address:
+          $ref: '#/components/schemas/CreateUserRequestBody_address'
+        phone:
+          nullable: true
+          type: string
+        website:
+          nullable: true
+          type: string
+        company:
+          $ref: '#/components/schemas/CreateUserRequestBody_company'
+      type: object
     UserResponseBody:
       $ref: '#/components/schemas/user'
     user:
@@ -209,6 +418,53 @@ components:
       - name
       - username
       type: object
+    UpdateUserResponseBody:
+      items:
+        $ref: '#/components/schemas/user'
+      type: array
+    UpdateUserRequestBody:
+      example:
+        website: website
+        address:
+          zipcode: zipcode
+          geo:
+            lon: lon
+            lat: lat
+          suite: suite
+          city: city
+          street: street
+        phone: phone
+        name: name
+        company:
+          bs: bs
+          catchPhrase: catchPhrase
+          name: name
+        email: email
+        username: username
+      properties:
+        name:
+          nullable: true
+          type: string
+        username:
+          nullable: true
+          type: string
+        email:
+          nullable: true
+          type: string
+        address:
+          $ref: '#/components/schemas/CreateUserRequestBody_address'
+        phone:
+          nullable: true
+          type: string
+        website:
+          nullable: true
+          type: string
+        company:
+          $ref: '#/components/schemas/CreateUserRequestBody_company'
+      type: object
+    DeleteUserResponseBody:
+      properties: {}
+      type: object
     UserDetailCommentListResponseBody:
       items:
         $ref: '#/components/schemas/PostDetailCommentListResponseBody_inner'
@@ -237,6 +493,59 @@ components:
       - id
       - name
       - postId
+      type: object
+    CreateUserRequestBody_address_geo:
+      example:
+        lon: lon
+        lat: lat
+      properties:
+        lat:
+          nullable: true
+          type: string
+        lon:
+          nullable: true
+          type: string
+      type: object
+    CreateUserRequestBody_address:
+      example:
+        zipcode: zipcode
+        geo:
+          lon: lon
+          lat: lat
+        suite: suite
+        city: city
+        street: street
+      properties:
+        street:
+          nullable: true
+          type: string
+        suite:
+          nullable: true
+          type: string
+        city:
+          nullable: true
+          type: string
+        zipcode:
+          nullable: true
+          type: string
+        geo:
+          $ref: '#/components/schemas/CreateUserRequestBody_address_geo'
+      type: object
+    CreateUserRequestBody_company:
+      example:
+        bs: bs
+        catchPhrase: catchPhrase
+        name: name
+      properties:
+        name:
+          nullable: true
+          type: string
+        catchPhrase:
+          nullable: true
+          type: string
+        bs:
+          nullable: true
+          type: string
       type: object
     user_address_geo:
       example:

--- a/openapi/web-practice-tech/openapi.yaml
+++ b/openapi/web-practice-tech/openapi.yaml
@@ -24,11 +24,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostsListResponseBody'
+                $ref: '#/components/schemas/GetPostsResponseBody'
           description: Successful response
       summary: すべての投稿を返却する
       tags:
-      - Posts
+      - posts
     post:
       description: N/A
       operationId: createPost
@@ -46,7 +46,7 @@ paths:
           description: Successful response
       summary: 投稿を登録する
       tags:
-      - Users
+      - users
   /posts/{postId}:
     delete:
       description: N/A
@@ -66,10 +66,10 @@ paths:
           description: Successful response
       summary: 指定されたIDの投稿を削除する.
       tags:
-      - Posts
+      - posts
     get:
       description: N/A
-      operationId: getPostDetail
+      operationId: getPost
       parameters:
       - in: path
         name: postId
@@ -81,11 +81,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostResponseBody'
+                $ref: '#/components/schemas/GetPostResponseBody'
           description: Successful response
       summary: 指定されたIDの投稿を取得する.
       tags:
-      - Posts
+      - posts
     put:
       description: N/A
       operationId: updatePost
@@ -109,11 +109,11 @@ paths:
           description: Successful response
       summary: 指定されたIDの投稿を更新する.
       tags:
-      - Posts
+      - posts
   /posts/{postId}/comments:
     get:
       description: N/A
-      operationId: getPostDetailCommentList
+      operationId: getPostComments
       parameters:
       - in: path
         name: postId
@@ -125,28 +125,28 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/PostDetailCommentListResponseBody'
+                $ref: '#/components/schemas/GetPostCommentsResponseBody'
           description: Successful response
       summary: 指定されたIDの投稿のコメントを取得する.
       tags:
-      - Posts
+      - posts
   /users:
     get:
       description: |-
         hogeに管理された投稿をすべて返却する.
         ドメイン知識どうのこうの、あれこれ、それそれで、使われているので、
         こうこうそれそれなので、このエンドポイントを削除することは、不可能.
-      operationId: getUserList
+      operationId: getUsers
       responses:
         "200":
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserListResponseBody'
+                $ref: '#/components/schemas/GetUsersResponseBody'
           description: Successful response
       summary: すべてのユーザを返却する
       tags:
-      - Users
+      - users
     post:
       description: N/A
       operationId: createUser
@@ -164,7 +164,7 @@ paths:
           description: Successful response
       summary: ユーザを登録する
       tags:
-      - Users
+      - users
   /users/{userId}:
     delete:
       description: N/A
@@ -184,10 +184,10 @@ paths:
           description: Successful response
       summary: 指定されたIDのユーザを削除する.
       tags:
-      - Users
+      - users
     get:
       description: N/A
-      operationId: getUserDetail
+      operationId: getUser
       parameters:
       - in: path
         name: userId
@@ -199,11 +199,11 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserResponseBody'
+                $ref: '#/components/schemas/GetUserResponseBody'
           description: Successful response
       summary: 指定されたIDのユーザを取得する.
       tags:
-      - Users
+      - users
     put:
       description: N/A
       operationId: updateUser
@@ -227,11 +227,11 @@ paths:
           description: Successful response
       summary: 指定されたIDのユーザを更新する.
       tags:
-      - Users
+      - users
   /users/{userId}/comments:
     get:
       description: N/A
-      operationId: getUserDetailCommentList
+      operationId: getUserComments
       parameters:
       - in: path
         name: userId
@@ -243,14 +243,14 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/UserDetailCommentListResponseBody'
+                $ref: '#/components/schemas/GetUserCommentsResponseBody'
           description: Successful response
       summary: 指定されたIDのユーザのコメントを取得する.
       tags:
-      - Users
+      - users
 components:
   schemas:
-    PostsListResponseBody:
+    GetPostsResponseBody:
       items:
         $ref: '#/components/schemas/post'
       type: array
@@ -274,7 +274,7 @@ components:
         completed:
           type: string
       type: object
-    PostResponseBody:
+    GetPostResponseBody:
       $ref: '#/components/schemas/post'
     post:
       example:
@@ -320,11 +320,11 @@ components:
     DeletePostResponseBody:
       properties: {}
       type: object
-    PostDetailCommentListResponseBody:
+    GetPostCommentsResponseBody:
       items:
-        $ref: '#/components/schemas/PostDetailCommentListResponseBody_inner'
+        $ref: '#/components/schemas/GetPostCommentsResponseBody_inner'
       type: array
-    UserListResponseBody:
+    GetUsersResponseBody:
       items:
         $ref: '#/components/schemas/user'
       type: array
@@ -372,7 +372,7 @@ components:
         company:
           $ref: '#/components/schemas/CreateUserRequestBody_company'
       type: object
-    UserResponseBody:
+    GetUserResponseBody:
       $ref: '#/components/schemas/user'
     user:
       example:
@@ -465,11 +465,11 @@ components:
     DeleteUserResponseBody:
       properties: {}
       type: object
-    UserDetailCommentListResponseBody:
+    GetUserCommentsResponseBody:
       items:
-        $ref: '#/components/schemas/PostDetailCommentListResponseBody_inner'
+        $ref: '#/components/schemas/GetPostCommentsResponseBody_inner'
       type: array
-    PostDetailCommentListResponseBody_inner:
+    GetPostCommentsResponseBody_inner:
       example:
         name: name
         id: 0

--- a/orval.config.ts
+++ b/orval.config.ts
@@ -6,13 +6,11 @@ export default defineConfig({
       target: './openapi/web-practice-tech/openapi.yaml',
     },
     output: {
-      target: './src/apis/backend.ts',
+      target: './src/__generated__/api.ts',
       client: 'react-query',
       clean: true,
       mode: 'tags-split',
       mock: true,
-      useExamples: true,
-      locale: 'ja',
       // prettier: true,
       // override: {
       //   // カスタムインスタンスを使う場合

--- a/src/__generated__/api.schemas.ts
+++ b/src/__generated__/api.schemas.ts
@@ -43,7 +43,7 @@ export interface CreateUserRequestBodyAddress {
   zipcode?: string | null;
 }
 
-export interface PostDetailCommentListResponseBodyInner {
+export interface GetPostCommentsResponseBodyInner {
   body: string;
   email: string;
   id: number;
@@ -51,7 +51,7 @@ export interface PostDetailCommentListResponseBodyInner {
   postId: number;
 }
 
-export type UserDetailCommentListResponseBody = PostDetailCommentListResponseBodyInner[];
+export type GetUserCommentsResponseBody = GetPostCommentsResponseBodyInner[];
 
 export interface DeleteUserResponseBody { [key: string]: any }
 
@@ -78,7 +78,7 @@ export interface User {
 
 export type UpdateUserResponseBody = User[];
 
-export type UserResponseBody = User;
+export type GetUserResponseBody = User;
 
 export interface CreateUserRequestBody {
   address?: CreateUserRequestBodyAddress;
@@ -92,9 +92,9 @@ export interface CreateUserRequestBody {
 
 export type CreateUserResponseBody = User[];
 
-export type UserListResponseBody = User[];
+export type GetUsersResponseBody = User[];
 
-export type PostDetailCommentListResponseBody = PostDetailCommentListResponseBodyInner[];
+export type GetPostCommentsResponseBody = GetPostCommentsResponseBodyInner[];
 
 export interface DeletePostResponseBody { [key: string]: any }
 
@@ -114,7 +114,7 @@ export interface Post {
 
 export type UpdatePostResponseBody = Post[];
 
-export type PostResponseBody = Post;
+export type GetPostResponseBody = Post;
 
 export interface CreatePostRequestBody {
   completed?: string;
@@ -125,5 +125,5 @@ export interface CreatePostRequestBody {
 
 export type CreatePostResponseBody = Post[];
 
-export type PostsListResponseBody = Post[];
+export type GetPostsResponseBody = Post[];
 

--- a/src/__generated__/posts/posts.msw.ts
+++ b/src/__generated__/posts/posts.msw.ts
@@ -18,11 +18,11 @@ export const getGetPostsMock = () => (Array.from({ length: faker.number.int({ mi
 
 export const getDeletePostMock = () => ({})
 
-export const getGetPostDetailMock = () => ({completed: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), title: faker.word.sample(), userId: faker.number.int({min: undefined, max: undefined})})
+export const getGetPostMock = () => ({completed: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), title: faker.word.sample(), userId: faker.number.int({min: undefined, max: undefined})})
 
 export const getUpdatePostMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({completed: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), title: faker.word.sample(), userId: faker.number.int({min: undefined, max: undefined})})))
 
-export const getGetPostDetailCommentListMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({body: faker.word.sample(), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), postId: faker.number.int({min: undefined, max: undefined})})))
+export const getGetPostCommentsMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({body: faker.word.sample(), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), postId: faker.number.int({min: undefined, max: undefined})})))
 
 export const getPostsMock = () => [
 http.get('*/posts', async () => {
@@ -47,7 +47,7 @@ http.get('*/posts', async () => {
         )
       }),http.get('*/posts/:postId', async () => {
         await delay(1000);
-        return new HttpResponse(JSON.stringify(getGetPostDetailMock()),
+        return new HttpResponse(JSON.stringify(getGetPostMock()),
           { 
             status: 200,
             headers: {
@@ -67,7 +67,7 @@ http.get('*/posts', async () => {
         )
       }),http.get('*/posts/:postId/comments', async () => {
         await delay(1000);
-        return new HttpResponse(JSON.stringify(getGetPostDetailCommentListMock()),
+        return new HttpResponse(JSON.stringify(getGetPostCommentsMock()),
           { 
             status: 200,
             headers: {

--- a/src/__generated__/posts/posts.ts
+++ b/src/__generated__/posts/posts.ts
@@ -25,12 +25,12 @@ import type {
 } from 'axios'
 import type {
   DeletePostResponseBody,
+  GetPostCommentsResponseBody,
+  GetPostsResponseBody,
   Post,
-  PostDetailCommentListResponseBody,
-  PostsListResponseBody,
   UpdatePostRequestBody,
   UpdatePostResponseBody
-} from '../backend.schemas'
+} from '../api.schemas'
 
 
 
@@ -42,7 +42,7 @@ import type {
  */
 export const getPosts = (
      options?: AxiosRequestConfig
- ): Promise<AxiosResponse<PostsListResponseBody>> => {
+ ): Promise<AxiosResponse<GetPostsResponseBody>> => {
     
     return axios.get(
       `/posts`,options
@@ -148,7 +148,7 @@ export const useDeletePost = <TError = AxiosError<unknown>,
  * N/A
  * @summary 指定されたIDの投稿を取得する.
  */
-export const getPostDetail = (
+export const getPost = (
     postId: string, options?: AxiosRequestConfig
  ): Promise<AxiosResponse<Post>> => {
     
@@ -158,41 +158,41 @@ export const getPostDetail = (
   }
 
 
-export const getGetPostDetailQueryKey = (postId: string,) => {
+export const getGetPostQueryKey = (postId: string,) => {
     return [`/posts/${postId}`] as const;
     }
 
     
-export const getGetPostDetailQueryOptions = <TData = Awaited<ReturnType<typeof getPostDetail>>, TError = AxiosError<unknown>>(postId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPostDetail>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const getGetPostQueryOptions = <TData = Awaited<ReturnType<typeof getPost>>, TError = AxiosError<unknown>>(postId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPost>>, TError, TData>>, axios?: AxiosRequestConfig}
 ) => {
 
 const {query: queryOptions, axios: axiosOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetPostDetailQueryKey(postId);
+  const queryKey =  queryOptions?.queryKey ?? getGetPostQueryKey(postId);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getPostDetail>>> = ({ signal }) => getPostDetail(postId, { signal, ...axiosOptions });
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getPost>>> = ({ signal }) => getPost(postId, { signal, ...axiosOptions });
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(postId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getPostDetail>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, enabled: !!(postId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getPost>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetPostDetailQueryResult = NonNullable<Awaited<ReturnType<typeof getPostDetail>>>
-export type GetPostDetailQueryError = AxiosError<unknown>
+export type GetPostQueryResult = NonNullable<Awaited<ReturnType<typeof getPost>>>
+export type GetPostQueryError = AxiosError<unknown>
 
 /**
  * @summary 指定されたIDの投稿を取得する.
  */
-export const useGetPostDetail = <TData = Awaited<ReturnType<typeof getPostDetail>>, TError = AxiosError<unknown>>(
- postId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPostDetail>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const useGetPost = <TData = Awaited<ReturnType<typeof getPost>>, TError = AxiosError<unknown>>(
+ postId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPost>>, TError, TData>>, axios?: AxiosRequestConfig}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
-  const queryOptions = getGetPostDetailQueryOptions(postId,options)
+  const queryOptions = getGetPostQueryOptions(postId,options)
 
   const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 
@@ -258,9 +258,9 @@ export const useUpdatePost = <TError = AxiosError<unknown>,
  * N/A
  * @summary 指定されたIDの投稿のコメントを取得する.
  */
-export const getPostDetailCommentList = (
+export const getPostComments = (
     postId: string, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<PostDetailCommentListResponseBody>> => {
+ ): Promise<AxiosResponse<GetPostCommentsResponseBody>> => {
     
     return axios.get(
       `/posts/${postId}/comments`,options
@@ -268,41 +268,41 @@ export const getPostDetailCommentList = (
   }
 
 
-export const getGetPostDetailCommentListQueryKey = (postId: string,) => {
+export const getGetPostCommentsQueryKey = (postId: string,) => {
     return [`/posts/${postId}/comments`] as const;
     }
 
     
-export const getGetPostDetailCommentListQueryOptions = <TData = Awaited<ReturnType<typeof getPostDetailCommentList>>, TError = AxiosError<unknown>>(postId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPostDetailCommentList>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const getGetPostCommentsQueryOptions = <TData = Awaited<ReturnType<typeof getPostComments>>, TError = AxiosError<unknown>>(postId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPostComments>>, TError, TData>>, axios?: AxiosRequestConfig}
 ) => {
 
 const {query: queryOptions, axios: axiosOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetPostDetailCommentListQueryKey(postId);
+  const queryKey =  queryOptions?.queryKey ?? getGetPostCommentsQueryKey(postId);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getPostDetailCommentList>>> = ({ signal }) => getPostDetailCommentList(postId, { signal, ...axiosOptions });
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getPostComments>>> = ({ signal }) => getPostComments(postId, { signal, ...axiosOptions });
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(postId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getPostDetailCommentList>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, enabled: !!(postId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getPostComments>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetPostDetailCommentListQueryResult = NonNullable<Awaited<ReturnType<typeof getPostDetailCommentList>>>
-export type GetPostDetailCommentListQueryError = AxiosError<unknown>
+export type GetPostCommentsQueryResult = NonNullable<Awaited<ReturnType<typeof getPostComments>>>
+export type GetPostCommentsQueryError = AxiosError<unknown>
 
 /**
  * @summary 指定されたIDの投稿のコメントを取得する.
  */
-export const useGetPostDetailCommentList = <TData = Awaited<ReturnType<typeof getPostDetailCommentList>>, TError = AxiosError<unknown>>(
- postId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPostDetailCommentList>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const useGetPostComments = <TData = Awaited<ReturnType<typeof getPostComments>>, TError = AxiosError<unknown>>(
+ postId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getPostComments>>, TError, TData>>, axios?: AxiosRequestConfig}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
-  const queryOptions = getGetPostDetailCommentListQueryOptions(postId,options)
+  const queryOptions = getGetPostCommentsQueryOptions(postId,options)
 
   const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 

--- a/src/__generated__/users/users.msw.ts
+++ b/src/__generated__/users/users.msw.ts
@@ -16,17 +16,17 @@ import {
 
 export const getCreatePostMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({completed: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), title: faker.word.sample(), userId: faker.number.int({min: undefined, max: undefined})})))
 
-export const getGetUserListMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({address: {city: faker.helpers.arrayElement([faker.word.sample(), undefined]), geo: faker.helpers.arrayElement([{lat: faker.helpers.arrayElement([faker.word.sample(), undefined]), lon: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), street: faker.helpers.arrayElement([faker.word.sample(), undefined]), suite: faker.helpers.arrayElement([faker.word.sample(), undefined]), zipcode: faker.helpers.arrayElement([faker.word.sample(), undefined])}, company: faker.helpers.arrayElement([{bs: faker.helpers.arrayElement([faker.word.sample(), undefined]), catchPhrase: faker.helpers.arrayElement([faker.word.sample(), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), phone: faker.helpers.arrayElement([faker.word.sample(), undefined]), username: faker.word.sample(), website: faker.helpers.arrayElement([faker.word.sample(), undefined])})))
+export const getGetUsersMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({address: {city: faker.helpers.arrayElement([faker.word.sample(), undefined]), geo: faker.helpers.arrayElement([{lat: faker.helpers.arrayElement([faker.word.sample(), undefined]), lon: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), street: faker.helpers.arrayElement([faker.word.sample(), undefined]), suite: faker.helpers.arrayElement([faker.word.sample(), undefined]), zipcode: faker.helpers.arrayElement([faker.word.sample(), undefined])}, company: faker.helpers.arrayElement([{bs: faker.helpers.arrayElement([faker.word.sample(), undefined]), catchPhrase: faker.helpers.arrayElement([faker.word.sample(), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), phone: faker.helpers.arrayElement([faker.word.sample(), undefined]), username: faker.word.sample(), website: faker.helpers.arrayElement([faker.word.sample(), undefined])})))
 
 export const getCreateUserMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({address: {city: faker.helpers.arrayElement([faker.word.sample(), undefined]), geo: faker.helpers.arrayElement([{lat: faker.helpers.arrayElement([faker.word.sample(), undefined]), lon: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), street: faker.helpers.arrayElement([faker.word.sample(), undefined]), suite: faker.helpers.arrayElement([faker.word.sample(), undefined]), zipcode: faker.helpers.arrayElement([faker.word.sample(), undefined])}, company: faker.helpers.arrayElement([{bs: faker.helpers.arrayElement([faker.word.sample(), undefined]), catchPhrase: faker.helpers.arrayElement([faker.word.sample(), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), phone: faker.helpers.arrayElement([faker.word.sample(), undefined]), username: faker.word.sample(), website: faker.helpers.arrayElement([faker.word.sample(), undefined])})))
 
 export const getDeleteUserMock = () => ({})
 
-export const getGetUserDetailMock = () => ({address: {city: faker.helpers.arrayElement([faker.word.sample(), undefined]), geo: faker.helpers.arrayElement([{lat: faker.helpers.arrayElement([faker.word.sample(), undefined]), lon: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), street: faker.helpers.arrayElement([faker.word.sample(), undefined]), suite: faker.helpers.arrayElement([faker.word.sample(), undefined]), zipcode: faker.helpers.arrayElement([faker.word.sample(), undefined])}, company: faker.helpers.arrayElement([{bs: faker.helpers.arrayElement([faker.word.sample(), undefined]), catchPhrase: faker.helpers.arrayElement([faker.word.sample(), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), phone: faker.helpers.arrayElement([faker.word.sample(), undefined]), username: faker.word.sample(), website: faker.helpers.arrayElement([faker.word.sample(), undefined])})
+export const getGetUserMock = () => ({address: {city: faker.helpers.arrayElement([faker.word.sample(), undefined]), geo: faker.helpers.arrayElement([{lat: faker.helpers.arrayElement([faker.word.sample(), undefined]), lon: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), street: faker.helpers.arrayElement([faker.word.sample(), undefined]), suite: faker.helpers.arrayElement([faker.word.sample(), undefined]), zipcode: faker.helpers.arrayElement([faker.word.sample(), undefined])}, company: faker.helpers.arrayElement([{bs: faker.helpers.arrayElement([faker.word.sample(), undefined]), catchPhrase: faker.helpers.arrayElement([faker.word.sample(), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), phone: faker.helpers.arrayElement([faker.word.sample(), undefined]), username: faker.word.sample(), website: faker.helpers.arrayElement([faker.word.sample(), undefined])})
 
 export const getUpdateUserMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({address: {city: faker.helpers.arrayElement([faker.word.sample(), undefined]), geo: faker.helpers.arrayElement([{lat: faker.helpers.arrayElement([faker.word.sample(), undefined]), lon: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), street: faker.helpers.arrayElement([faker.word.sample(), undefined]), suite: faker.helpers.arrayElement([faker.word.sample(), undefined]), zipcode: faker.helpers.arrayElement([faker.word.sample(), undefined])}, company: faker.helpers.arrayElement([{bs: faker.helpers.arrayElement([faker.word.sample(), undefined]), catchPhrase: faker.helpers.arrayElement([faker.word.sample(), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), phone: faker.helpers.arrayElement([faker.word.sample(), undefined]), username: faker.word.sample(), website: faker.helpers.arrayElement([faker.word.sample(), undefined])})))
 
-export const getGetUserDetailCommentListMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({body: faker.word.sample(), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), postId: faker.number.int({min: undefined, max: undefined})})))
+export const getGetUserCommentsMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({body: faker.word.sample(), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), postId: faker.number.int({min: undefined, max: undefined})})))
 
 export const getUsersMock = () => [
 http.post('*/posts', async () => {
@@ -41,7 +41,7 @@ http.post('*/posts', async () => {
         )
       }),http.get('*/users', async () => {
         await delay(1000);
-        return new HttpResponse(JSON.stringify(getGetUserListMock()),
+        return new HttpResponse(JSON.stringify(getGetUsersMock()),
           { 
             status: 200,
             headers: {
@@ -71,7 +71,7 @@ http.post('*/posts', async () => {
         )
       }),http.get('*/users/:userId', async () => {
         await delay(1000);
-        return new HttpResponse(JSON.stringify(getGetUserDetailMock()),
+        return new HttpResponse(JSON.stringify(getGetUserMock()),
           { 
             status: 200,
             headers: {
@@ -91,7 +91,7 @@ http.post('*/posts', async () => {
         )
       }),http.get('*/users/:userId/comments', async () => {
         await delay(1000);
-        return new HttpResponse(JSON.stringify(getGetUserDetailCommentListMock()),
+        return new HttpResponse(JSON.stringify(getGetUserCommentsMock()),
           { 
             status: 200,
             headers: {

--- a/src/__generated__/users/users.ts
+++ b/src/__generated__/users/users.ts
@@ -29,12 +29,12 @@ import type {
   CreateUserRequestBody,
   CreateUserResponseBody,
   DeleteUserResponseBody,
+  GetUserCommentsResponseBody,
+  GetUsersResponseBody,
   UpdateUserRequestBody,
   UpdateUserResponseBody,
-  User,
-  UserDetailCommentListResponseBody,
-  UserListResponseBody
-} from '../backend.schemas'
+  User
+} from '../api.schemas'
 
 
 
@@ -94,9 +94,9 @@ export const useCreatePost = <TError = AxiosError<unknown>,
 こうこうそれそれなので、このエンドポイントを削除することは、不可能.
  * @summary すべてのユーザを返却する
  */
-export const getUserList = (
+export const getUsers = (
      options?: AxiosRequestConfig
- ): Promise<AxiosResponse<UserListResponseBody>> => {
+ ): Promise<AxiosResponse<GetUsersResponseBody>> => {
     
     return axios.get(
       `/users`,options
@@ -104,41 +104,41 @@ export const getUserList = (
   }
 
 
-export const getGetUserListQueryKey = () => {
+export const getGetUsersQueryKey = () => {
     return [`/users`] as const;
     }
 
     
-export const getGetUserListQueryOptions = <TData = Awaited<ReturnType<typeof getUserList>>, TError = AxiosError<unknown>>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserList>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const getGetUsersQueryOptions = <TData = Awaited<ReturnType<typeof getUsers>>, TError = AxiosError<unknown>>( options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUsers>>, TError, TData>>, axios?: AxiosRequestConfig}
 ) => {
 
 const {query: queryOptions, axios: axiosOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetUserListQueryKey();
+  const queryKey =  queryOptions?.queryKey ?? getGetUsersQueryKey();
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserList>>> = ({ signal }) => getUserList({ signal, ...axiosOptions });
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getUsers>>> = ({ signal }) => getUsers({ signal, ...axiosOptions });
 
       
 
       
 
-   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getUserList>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getUsers>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetUserListQueryResult = NonNullable<Awaited<ReturnType<typeof getUserList>>>
-export type GetUserListQueryError = AxiosError<unknown>
+export type GetUsersQueryResult = NonNullable<Awaited<ReturnType<typeof getUsers>>>
+export type GetUsersQueryError = AxiosError<unknown>
 
 /**
  * @summary すべてのユーザを返却する
  */
-export const useGetUserList = <TData = Awaited<ReturnType<typeof getUserList>>, TError = AxiosError<unknown>>(
-  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserList>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const useGetUsers = <TData = Awaited<ReturnType<typeof getUsers>>, TError = AxiosError<unknown>>(
+  options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUsers>>, TError, TData>>, axios?: AxiosRequestConfig}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
-  const queryOptions = getGetUserListQueryOptions(options)
+  const queryOptions = getGetUsersQueryOptions(options)
 
   const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 
@@ -252,7 +252,7 @@ export const useDeleteUser = <TError = AxiosError<unknown>,
  * N/A
  * @summary 指定されたIDのユーザを取得する.
  */
-export const getUserDetail = (
+export const getUser = (
     userId: string, options?: AxiosRequestConfig
  ): Promise<AxiosResponse<User>> => {
     
@@ -262,41 +262,41 @@ export const getUserDetail = (
   }
 
 
-export const getGetUserDetailQueryKey = (userId: string,) => {
+export const getGetUserQueryKey = (userId: string,) => {
     return [`/users/${userId}`] as const;
     }
 
     
-export const getGetUserDetailQueryOptions = <TData = Awaited<ReturnType<typeof getUserDetail>>, TError = AxiosError<unknown>>(userId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserDetail>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const getGetUserQueryOptions = <TData = Awaited<ReturnType<typeof getUser>>, TError = AxiosError<unknown>>(userId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUser>>, TError, TData>>, axios?: AxiosRequestConfig}
 ) => {
 
 const {query: queryOptions, axios: axiosOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetUserDetailQueryKey(userId);
+  const queryKey =  queryOptions?.queryKey ?? getGetUserQueryKey(userId);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserDetail>>> = ({ signal }) => getUserDetail(userId, { signal, ...axiosOptions });
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getUser>>> = ({ signal }) => getUser(userId, { signal, ...axiosOptions });
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(userId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getUserDetail>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, enabled: !!(userId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getUser>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetUserDetailQueryResult = NonNullable<Awaited<ReturnType<typeof getUserDetail>>>
-export type GetUserDetailQueryError = AxiosError<unknown>
+export type GetUserQueryResult = NonNullable<Awaited<ReturnType<typeof getUser>>>
+export type GetUserQueryError = AxiosError<unknown>
 
 /**
  * @summary 指定されたIDのユーザを取得する.
  */
-export const useGetUserDetail = <TData = Awaited<ReturnType<typeof getUserDetail>>, TError = AxiosError<unknown>>(
- userId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserDetail>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const useGetUser = <TData = Awaited<ReturnType<typeof getUser>>, TError = AxiosError<unknown>>(
+ userId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUser>>, TError, TData>>, axios?: AxiosRequestConfig}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
-  const queryOptions = getGetUserDetailQueryOptions(userId,options)
+  const queryOptions = getGetUserQueryOptions(userId,options)
 
   const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 
@@ -362,9 +362,9 @@ export const useUpdateUser = <TError = AxiosError<unknown>,
  * N/A
  * @summary 指定されたIDのユーザのコメントを取得する.
  */
-export const getUserDetailCommentList = (
+export const getUserComments = (
     userId: string, options?: AxiosRequestConfig
- ): Promise<AxiosResponse<UserDetailCommentListResponseBody>> => {
+ ): Promise<AxiosResponse<GetUserCommentsResponseBody>> => {
     
     return axios.get(
       `/users/${userId}/comments`,options
@@ -372,41 +372,41 @@ export const getUserDetailCommentList = (
   }
 
 
-export const getGetUserDetailCommentListQueryKey = (userId: string,) => {
+export const getGetUserCommentsQueryKey = (userId: string,) => {
     return [`/users/${userId}/comments`] as const;
     }
 
     
-export const getGetUserDetailCommentListQueryOptions = <TData = Awaited<ReturnType<typeof getUserDetailCommentList>>, TError = AxiosError<unknown>>(userId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserDetailCommentList>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const getGetUserCommentsQueryOptions = <TData = Awaited<ReturnType<typeof getUserComments>>, TError = AxiosError<unknown>>(userId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserComments>>, TError, TData>>, axios?: AxiosRequestConfig}
 ) => {
 
 const {query: queryOptions, axios: axiosOptions} = options ?? {};
 
-  const queryKey =  queryOptions?.queryKey ?? getGetUserDetailCommentListQueryKey(userId);
+  const queryKey =  queryOptions?.queryKey ?? getGetUserCommentsQueryKey(userId);
 
   
 
-    const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserDetailCommentList>>> = ({ signal }) => getUserDetailCommentList(userId, { signal, ...axiosOptions });
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserComments>>> = ({ signal }) => getUserComments(userId, { signal, ...axiosOptions });
 
       
 
       
 
-   return  { queryKey, queryFn, enabled: !!(userId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getUserDetailCommentList>>, TError, TData> & { queryKey: QueryKey }
+   return  { queryKey, queryFn, enabled: !!(userId), ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof getUserComments>>, TError, TData> & { queryKey: QueryKey }
 }
 
-export type GetUserDetailCommentListQueryResult = NonNullable<Awaited<ReturnType<typeof getUserDetailCommentList>>>
-export type GetUserDetailCommentListQueryError = AxiosError<unknown>
+export type GetUserCommentsQueryResult = NonNullable<Awaited<ReturnType<typeof getUserComments>>>
+export type GetUserCommentsQueryError = AxiosError<unknown>
 
 /**
  * @summary 指定されたIDのユーザのコメントを取得する.
  */
-export const useGetUserDetailCommentList = <TData = Awaited<ReturnType<typeof getUserDetailCommentList>>, TError = AxiosError<unknown>>(
- userId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserDetailCommentList>>, TError, TData>>, axios?: AxiosRequestConfig}
+export const useGetUserComments = <TData = Awaited<ReturnType<typeof getUserComments>>, TError = AxiosError<unknown>>(
+ userId: string, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof getUserComments>>, TError, TData>>, axios?: AxiosRequestConfig}
 
   ):  UseQueryResult<TData, TError> & { queryKey: QueryKey } => {
 
-  const queryOptions = getGetUserDetailCommentListQueryOptions(userId,options)
+  const queryOptions = getGetUserCommentsQueryOptions(userId,options)
 
   const query = useQuery(queryOptions) as  UseQueryResult<TData, TError> & { queryKey: QueryKey };
 

--- a/src/apis/backend.schemas.ts
+++ b/src/apis/backend.schemas.ts
@@ -24,6 +24,25 @@ export interface UserAddress {
   zipcode?: string;
 }
 
+export interface CreateUserRequestBodyCompany {
+  bs?: string | null;
+  catchPhrase?: string | null;
+  name?: string | null;
+}
+
+export interface CreateUserRequestBodyAddressGeo {
+  lat?: string | null;
+  lon?: string | null;
+}
+
+export interface CreateUserRequestBodyAddress {
+  city?: string | null;
+  geo?: CreateUserRequestBodyAddressGeo;
+  street?: string | null;
+  suite?: string | null;
+  zipcode?: string | null;
+}
+
 export interface PostDetailCommentListResponseBodyInner {
   body: string;
   email: string;
@@ -33,6 +52,18 @@ export interface PostDetailCommentListResponseBodyInner {
 }
 
 export type UserDetailCommentListResponseBody = PostDetailCommentListResponseBodyInner[];
+
+export interface DeleteUserResponseBody { [key: string]: any }
+
+export interface UpdateUserRequestBody {
+  address?: CreateUserRequestBodyAddress;
+  company?: CreateUserRequestBodyCompany;
+  email?: string | null;
+  name?: string | null;
+  phone?: string | null;
+  username?: string | null;
+  website?: string | null;
+}
 
 export interface User {
   address: UserAddress;
@@ -45,11 +76,34 @@ export interface User {
   website?: string;
 }
 
+export type UpdateUserResponseBody = User[];
+
 export type UserResponseBody = User;
+
+export interface CreateUserRequestBody {
+  address?: CreateUserRequestBodyAddress;
+  company?: CreateUserRequestBodyCompany;
+  email?: string | null;
+  name?: string | null;
+  phone?: string | null;
+  username?: string | null;
+  website?: string | null;
+}
+
+export type CreateUserResponseBody = User[];
 
 export type UserListResponseBody = User[];
 
 export type PostDetailCommentListResponseBody = PostDetailCommentListResponseBodyInner[];
+
+export interface DeletePostResponseBody { [key: string]: any }
+
+export interface UpdatePostRequestBody {
+  completed?: string;
+  id?: number;
+  title?: string;
+  userId?: number;
+}
 
 export interface Post {
   completed: string;
@@ -58,7 +112,18 @@ export interface Post {
   userId: number;
 }
 
+export type UpdatePostResponseBody = Post[];
+
 export type PostResponseBody = Post;
+
+export interface CreatePostRequestBody {
+  completed?: string;
+  id?: number;
+  title?: string;
+  userId?: number;
+}
+
+export type CreatePostResponseBody = Post[];
 
 export type PostsListResponseBody = Post[];
 

--- a/src/apis/posts/posts.msw.ts
+++ b/src/apis/posts/posts.msw.ts
@@ -16,7 +16,11 @@ import {
 
 export const getGetPostsMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({completed: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), title: faker.word.sample(), userId: faker.number.int({min: undefined, max: undefined})})))
 
+export const getDeletePostMock = () => ({})
+
 export const getGetPostDetailMock = () => ({completed: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), title: faker.word.sample(), userId: faker.number.int({min: undefined, max: undefined})})
+
+export const getUpdatePostMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({completed: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), title: faker.word.sample(), userId: faker.number.int({min: undefined, max: undefined})})))
 
 export const getGetPostDetailCommentListMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({body: faker.word.sample(), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), postId: faker.number.int({min: undefined, max: undefined})})))
 
@@ -31,9 +35,29 @@ http.get('*/posts', async () => {
             }
           }
         )
+      }),http.delete('*/posts/:postId', async () => {
+        await delay(1000);
+        return new HttpResponse(JSON.stringify(getDeletePostMock()),
+          { 
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            }
+          }
+        )
       }),http.get('*/posts/:postId', async () => {
         await delay(1000);
         return new HttpResponse(JSON.stringify(getGetPostDetailMock()),
+          { 
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            }
+          }
+        )
+      }),http.put('*/posts/:postId', async () => {
+        await delay(1000);
+        return new HttpResponse(JSON.stringify(getUpdatePostMock()),
           { 
             status: 200,
             headers: {

--- a/src/apis/posts/posts.ts
+++ b/src/apis/posts/posts.ts
@@ -6,11 +6,14 @@
  * OpenAPI spec version: 0.0.1
  */
 import {
+  useMutation,
   useQuery
 } from '@tanstack/react-query'
 import type {
+  MutationFunction,
   QueryFunction,
   QueryKey,
+  UseMutationOptions,
   UseQueryOptions,
   UseQueryResult
 } from '@tanstack/react-query'
@@ -21,9 +24,12 @@ import type {
   AxiosResponse
 } from 'axios'
 import type {
+  DeletePostResponseBody,
   Post,
   PostDetailCommentListResponseBody,
-  PostsListResponseBody
+  PostsListResponseBody,
+  UpdatePostRequestBody,
+  UpdatePostResponseBody
 } from '../backend.schemas'
 
 
@@ -91,6 +97,55 @@ export const useGetPosts = <TData = Awaited<ReturnType<typeof getPosts>>, TError
 
 /**
  * N/A
+ * @summary 指定されたIDの投稿を削除する.
+ */
+export const deletePost = (
+    postId: string, options?: AxiosRequestConfig
+ ): Promise<AxiosResponse<DeletePostResponseBody>> => {
+    
+    return axios.delete(
+      `/posts/${postId}`,options
+    );
+  }
+
+
+
+export const getDeletePostMutationOptions = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deletePost>>, TError,{postId: string}, TContext>, axios?: AxiosRequestConfig}
+): UseMutationOptions<Awaited<ReturnType<typeof deletePost>>, TError,{postId: string}, TContext> => {
+ const {mutation: mutationOptions, axios: axiosOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deletePost>>, {postId: string}> = (props) => {
+          const {postId} = props ?? {};
+
+          return  deletePost(postId,axiosOptions)
+        }
+
+        
+
+
+   return  { mutationFn, ...mutationOptions }}
+
+    export type DeletePostMutationResult = NonNullable<Awaited<ReturnType<typeof deletePost>>>
+    
+    export type DeletePostMutationError = AxiosError<unknown>
+
+    /**
+ * @summary 指定されたIDの投稿を削除する.
+ */
+export const useDeletePost = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deletePost>>, TError,{postId: string}, TContext>, axios?: AxiosRequestConfig}
+) => {
+
+      const mutationOptions = getDeletePostMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    /**
+ * N/A
  * @summary 指定されたIDの投稿を取得する.
  */
 export const getPostDetail = (
@@ -149,6 +204,57 @@ export const useGetPostDetail = <TData = Awaited<ReturnType<typeof getPostDetail
 
 
 /**
+ * N/A
+ * @summary 指定されたIDの投稿を更新する.
+ */
+export const updatePost = (
+    postId: string,
+    updatePostRequestBody: UpdatePostRequestBody, options?: AxiosRequestConfig
+ ): Promise<AxiosResponse<UpdatePostResponseBody>> => {
+    
+    return axios.put(
+      `/posts/${postId}`,
+      updatePostRequestBody,options
+    );
+  }
+
+
+
+export const getUpdatePostMutationOptions = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof updatePost>>, TError,{postId: string;data: UpdatePostRequestBody}, TContext>, axios?: AxiosRequestConfig}
+): UseMutationOptions<Awaited<ReturnType<typeof updatePost>>, TError,{postId: string;data: UpdatePostRequestBody}, TContext> => {
+ const {mutation: mutationOptions, axios: axiosOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof updatePost>>, {postId: string;data: UpdatePostRequestBody}> = (props) => {
+          const {postId,data} = props ?? {};
+
+          return  updatePost(postId,data,axiosOptions)
+        }
+
+        
+
+
+   return  { mutationFn, ...mutationOptions }}
+
+    export type UpdatePostMutationResult = NonNullable<Awaited<ReturnType<typeof updatePost>>>
+    export type UpdatePostMutationBody = UpdatePostRequestBody
+    export type UpdatePostMutationError = AxiosError<unknown>
+
+    /**
+ * @summary 指定されたIDの投稿を更新する.
+ */
+export const useUpdatePost = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof updatePost>>, TError,{postId: string;data: UpdatePostRequestBody}, TContext>, axios?: AxiosRequestConfig}
+) => {
+
+      const mutationOptions = getUpdatePostMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    /**
  * N/A
  * @summary 指定されたIDの投稿のコメントを取得する.
  */

--- a/src/apis/users/users.msw.ts
+++ b/src/apis/users/users.msw.ts
@@ -14,16 +14,54 @@ import {
   http
 } from 'msw'
 
+export const getCreatePostMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({completed: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), title: faker.word.sample(), userId: faker.number.int({min: undefined, max: undefined})})))
+
 export const getGetUserListMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({address: {city: faker.helpers.arrayElement([faker.word.sample(), undefined]), geo: faker.helpers.arrayElement([{lat: faker.helpers.arrayElement([faker.word.sample(), undefined]), lon: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), street: faker.helpers.arrayElement([faker.word.sample(), undefined]), suite: faker.helpers.arrayElement([faker.word.sample(), undefined]), zipcode: faker.helpers.arrayElement([faker.word.sample(), undefined])}, company: faker.helpers.arrayElement([{bs: faker.helpers.arrayElement([faker.word.sample(), undefined]), catchPhrase: faker.helpers.arrayElement([faker.word.sample(), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), phone: faker.helpers.arrayElement([faker.word.sample(), undefined]), username: faker.word.sample(), website: faker.helpers.arrayElement([faker.word.sample(), undefined])})))
 
+export const getCreateUserMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({address: {city: faker.helpers.arrayElement([faker.word.sample(), undefined]), geo: faker.helpers.arrayElement([{lat: faker.helpers.arrayElement([faker.word.sample(), undefined]), lon: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), street: faker.helpers.arrayElement([faker.word.sample(), undefined]), suite: faker.helpers.arrayElement([faker.word.sample(), undefined]), zipcode: faker.helpers.arrayElement([faker.word.sample(), undefined])}, company: faker.helpers.arrayElement([{bs: faker.helpers.arrayElement([faker.word.sample(), undefined]), catchPhrase: faker.helpers.arrayElement([faker.word.sample(), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), phone: faker.helpers.arrayElement([faker.word.sample(), undefined]), username: faker.word.sample(), website: faker.helpers.arrayElement([faker.word.sample(), undefined])})))
+
+export const getDeleteUserMock = () => ({})
+
 export const getGetUserDetailMock = () => ({address: {city: faker.helpers.arrayElement([faker.word.sample(), undefined]), geo: faker.helpers.arrayElement([{lat: faker.helpers.arrayElement([faker.word.sample(), undefined]), lon: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), street: faker.helpers.arrayElement([faker.word.sample(), undefined]), suite: faker.helpers.arrayElement([faker.word.sample(), undefined]), zipcode: faker.helpers.arrayElement([faker.word.sample(), undefined])}, company: faker.helpers.arrayElement([{bs: faker.helpers.arrayElement([faker.word.sample(), undefined]), catchPhrase: faker.helpers.arrayElement([faker.word.sample(), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), phone: faker.helpers.arrayElement([faker.word.sample(), undefined]), username: faker.word.sample(), website: faker.helpers.arrayElement([faker.word.sample(), undefined])})
+
+export const getUpdateUserMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({address: {city: faker.helpers.arrayElement([faker.word.sample(), undefined]), geo: faker.helpers.arrayElement([{lat: faker.helpers.arrayElement([faker.word.sample(), undefined]), lon: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), street: faker.helpers.arrayElement([faker.word.sample(), undefined]), suite: faker.helpers.arrayElement([faker.word.sample(), undefined]), zipcode: faker.helpers.arrayElement([faker.word.sample(), undefined])}, company: faker.helpers.arrayElement([{bs: faker.helpers.arrayElement([faker.word.sample(), undefined]), catchPhrase: faker.helpers.arrayElement([faker.word.sample(), undefined]), name: faker.helpers.arrayElement([faker.word.sample(), undefined])}, undefined]), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), phone: faker.helpers.arrayElement([faker.word.sample(), undefined]), username: faker.word.sample(), website: faker.helpers.arrayElement([faker.word.sample(), undefined])})))
 
 export const getGetUserDetailCommentListMock = () => (Array.from({ length: faker.number.int({ min: 1, max: 10 }) }, (_, i) => i + 1).map(() => ({body: faker.word.sample(), email: faker.word.sample(), id: faker.number.int({min: undefined, max: undefined}), name: faker.word.sample(), postId: faker.number.int({min: undefined, max: undefined})})))
 
 export const getUsersMock = () => [
-http.get('*/users', async () => {
+http.post('*/posts', async () => {
+        await delay(1000);
+        return new HttpResponse(JSON.stringify(getCreatePostMock()),
+          { 
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            }
+          }
+        )
+      }),http.get('*/users', async () => {
         await delay(1000);
         return new HttpResponse(JSON.stringify(getGetUserListMock()),
+          { 
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            }
+          }
+        )
+      }),http.post('*/users', async () => {
+        await delay(1000);
+        return new HttpResponse(JSON.stringify(getCreateUserMock()),
+          { 
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            }
+          }
+        )
+      }),http.delete('*/users/:userId', async () => {
+        await delay(1000);
+        return new HttpResponse(JSON.stringify(getDeleteUserMock()),
           { 
             status: 200,
             headers: {
@@ -34,6 +72,16 @@ http.get('*/users', async () => {
       }),http.get('*/users/:userId', async () => {
         await delay(1000);
         return new HttpResponse(JSON.stringify(getGetUserDetailMock()),
+          { 
+            status: 200,
+            headers: {
+              'Content-Type': 'application/json',
+            }
+          }
+        )
+      }),http.put('*/users/:userId', async () => {
+        await delay(1000);
+        return new HttpResponse(JSON.stringify(getUpdateUserMock()),
           { 
             status: 200,
             headers: {

--- a/src/apis/users/users.ts
+++ b/src/apis/users/users.ts
@@ -6,11 +6,14 @@
  * OpenAPI spec version: 0.0.1
  */
 import {
+  useMutation,
   useQuery
 } from '@tanstack/react-query'
 import type {
+  MutationFunction,
   QueryFunction,
   QueryKey,
+  UseMutationOptions,
   UseQueryOptions,
   UseQueryResult
 } from '@tanstack/react-query'
@@ -21,6 +24,13 @@ import type {
   AxiosResponse
 } from 'axios'
 import type {
+  CreatePostRequestBody,
+  CreatePostResponseBody,
+  CreateUserRequestBody,
+  CreateUserResponseBody,
+  DeleteUserResponseBody,
+  UpdateUserRequestBody,
+  UpdateUserResponseBody,
   User,
   UserDetailCommentListResponseBody,
   UserListResponseBody
@@ -29,6 +39,56 @@ import type {
 
 
 /**
+ * N/A
+ * @summary 投稿を登録する
+ */
+export const createPost = (
+    createPostRequestBody: CreatePostRequestBody, options?: AxiosRequestConfig
+ ): Promise<AxiosResponse<CreatePostResponseBody>> => {
+    
+    return axios.post(
+      `/posts`,
+      createPostRequestBody,options
+    );
+  }
+
+
+
+export const getCreatePostMutationOptions = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createPost>>, TError,{data: CreatePostRequestBody}, TContext>, axios?: AxiosRequestConfig}
+): UseMutationOptions<Awaited<ReturnType<typeof createPost>>, TError,{data: CreatePostRequestBody}, TContext> => {
+ const {mutation: mutationOptions, axios: axiosOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof createPost>>, {data: CreatePostRequestBody}> = (props) => {
+          const {data} = props ?? {};
+
+          return  createPost(data,axiosOptions)
+        }
+
+        
+
+
+   return  { mutationFn, ...mutationOptions }}
+
+    export type CreatePostMutationResult = NonNullable<Awaited<ReturnType<typeof createPost>>>
+    export type CreatePostMutationBody = CreatePostRequestBody
+    export type CreatePostMutationError = AxiosError<unknown>
+
+    /**
+ * @summary 投稿を登録する
+ */
+export const useCreatePost = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createPost>>, TError,{data: CreatePostRequestBody}, TContext>, axios?: AxiosRequestConfig}
+) => {
+
+      const mutationOptions = getCreatePostMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    /**
  * hogeに管理された投稿をすべて返却する.
 ドメイン知識どうのこうの、あれこれ、それそれで、使われているので、
 こうこうそれそれなので、このエンドポイントを削除することは、不可能.
@@ -91,6 +151,105 @@ export const useGetUserList = <TData = Awaited<ReturnType<typeof getUserList>>, 
 
 /**
  * N/A
+ * @summary ユーザを登録する
+ */
+export const createUser = (
+    createUserRequestBody: CreateUserRequestBody, options?: AxiosRequestConfig
+ ): Promise<AxiosResponse<CreateUserResponseBody>> => {
+    
+    return axios.post(
+      `/users`,
+      createUserRequestBody,options
+    );
+  }
+
+
+
+export const getCreateUserMutationOptions = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createUser>>, TError,{data: CreateUserRequestBody}, TContext>, axios?: AxiosRequestConfig}
+): UseMutationOptions<Awaited<ReturnType<typeof createUser>>, TError,{data: CreateUserRequestBody}, TContext> => {
+ const {mutation: mutationOptions, axios: axiosOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof createUser>>, {data: CreateUserRequestBody}> = (props) => {
+          const {data} = props ?? {};
+
+          return  createUser(data,axiosOptions)
+        }
+
+        
+
+
+   return  { mutationFn, ...mutationOptions }}
+
+    export type CreateUserMutationResult = NonNullable<Awaited<ReturnType<typeof createUser>>>
+    export type CreateUserMutationBody = CreateUserRequestBody
+    export type CreateUserMutationError = AxiosError<unknown>
+
+    /**
+ * @summary ユーザを登録する
+ */
+export const useCreateUser = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof createUser>>, TError,{data: CreateUserRequestBody}, TContext>, axios?: AxiosRequestConfig}
+) => {
+
+      const mutationOptions = getCreateUserMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    /**
+ * N/A
+ * @summary 指定されたIDのユーザを削除する.
+ */
+export const deleteUser = (
+    userId: string, options?: AxiosRequestConfig
+ ): Promise<AxiosResponse<DeleteUserResponseBody>> => {
+    
+    return axios.delete(
+      `/users/${userId}`,options
+    );
+  }
+
+
+
+export const getDeleteUserMutationOptions = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteUser>>, TError,{userId: string}, TContext>, axios?: AxiosRequestConfig}
+): UseMutationOptions<Awaited<ReturnType<typeof deleteUser>>, TError,{userId: string}, TContext> => {
+ const {mutation: mutationOptions, axios: axiosOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof deleteUser>>, {userId: string}> = (props) => {
+          const {userId} = props ?? {};
+
+          return  deleteUser(userId,axiosOptions)
+        }
+
+        
+
+
+   return  { mutationFn, ...mutationOptions }}
+
+    export type DeleteUserMutationResult = NonNullable<Awaited<ReturnType<typeof deleteUser>>>
+    
+    export type DeleteUserMutationError = AxiosError<unknown>
+
+    /**
+ * @summary 指定されたIDのユーザを削除する.
+ */
+export const useDeleteUser = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof deleteUser>>, TError,{userId: string}, TContext>, axios?: AxiosRequestConfig}
+) => {
+
+      const mutationOptions = getDeleteUserMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    /**
+ * N/A
  * @summary 指定されたIDのユーザを取得する.
  */
 export const getUserDetail = (
@@ -149,6 +308,57 @@ export const useGetUserDetail = <TData = Awaited<ReturnType<typeof getUserDetail
 
 
 /**
+ * N/A
+ * @summary 指定されたIDのユーザを更新する.
+ */
+export const updateUser = (
+    userId: string,
+    updateUserRequestBody: UpdateUserRequestBody, options?: AxiosRequestConfig
+ ): Promise<AxiosResponse<UpdateUserResponseBody>> => {
+    
+    return axios.put(
+      `/users/${userId}`,
+      updateUserRequestBody,options
+    );
+  }
+
+
+
+export const getUpdateUserMutationOptions = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof updateUser>>, TError,{userId: string;data: UpdateUserRequestBody}, TContext>, axios?: AxiosRequestConfig}
+): UseMutationOptions<Awaited<ReturnType<typeof updateUser>>, TError,{userId: string;data: UpdateUserRequestBody}, TContext> => {
+ const {mutation: mutationOptions, axios: axiosOptions} = options ?? {};
+
+      
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof updateUser>>, {userId: string;data: UpdateUserRequestBody}> = (props) => {
+          const {userId,data} = props ?? {};
+
+          return  updateUser(userId,data,axiosOptions)
+        }
+
+        
+
+
+   return  { mutationFn, ...mutationOptions }}
+
+    export type UpdateUserMutationResult = NonNullable<Awaited<ReturnType<typeof updateUser>>>
+    export type UpdateUserMutationBody = UpdateUserRequestBody
+    export type UpdateUserMutationError = AxiosError<unknown>
+
+    /**
+ * @summary 指定されたIDのユーザを更新する.
+ */
+export const useUpdateUser = <TError = AxiosError<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof updateUser>>, TError,{userId: string;data: UpdateUserRequestBody}, TContext>, axios?: AxiosRequestConfig}
+) => {
+
+      const mutationOptions = getUpdateUserMutationOptions(options);
+
+      return useMutation(mutationOptions);
+    }
+    /**
  * N/A
  * @summary 指定されたIDのユーザのコメントを取得する.
  */

--- a/src/screens/app-router/tanstack/useGetPostList.ts
+++ b/src/screens/app-router/tanstack/useGetPostList.ts
@@ -1,11 +1,11 @@
-import { PostsListResponseBody } from '@/apis/backend.schemas';
-import { useGetPosts, GetPostsQueryResult } from '@/apis/posts/posts';
+import type { GetPostsResponseBody } from '@/__generated__/api.schemas';
+import { useGetPosts, GetPostsQueryResult } from '@/__generated__/posts/posts';
 
 
 // NOTE: API取得後のロジック、ここをテストコード書けばよいだけにしておきたい.
 //       さらに、selectorなロジックは別ファイルに切り出すか・・・？
-const postFilter = (response: GetPostsQueryResult): PostsListResponseBody => {
-  const data: PostsListResponseBody = response.data
+const postFilter = (response: GetPostsQueryResult): GetPostsResponseBody => {
+  const data: GetPostsResponseBody = response.data
   return data.map(({ id, title, userId, completed }) => {
     return {
       id,

--- a/web-api-designs/web-practice-tech/index.yaml
+++ b/web-api-designs/web-practice-tech/index.yaml
@@ -7,6 +7,7 @@ servers:
   - url: https://jsonplaceholder.typicode.com
     description: Development server
 
+## Rule: テーブル名
 tags:
   - name: posts
     description: 投稿

--- a/web-api-designs/web-practice-tech/paths/posts/post.yaml
+++ b/web-api-designs/web-practice-tech/paths/posts/post.yaml
@@ -4,7 +4,8 @@ get:
     hogeに管理された投稿をすべて返却する.
     ドメイン知識どうのこうの、あれこれ、それそれで、使われているので、
     こうこうそれそれなので、このエンドポイントを削除することは、不可能.
-  tags: [Posts]
+  tags:
+    - posts
   operationId: getPosts
   responses:
     "200":
@@ -12,12 +13,13 @@ get:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/PostsListResponseBody"
+            $ref: "#/components/schemas/GetPostsResponseBody"
 
 post:
   summary: 投稿を登録する
   description: N/A
-  tags: [Users]
+  tags:
+    - users
   operationId: createPost
   requestBody:
     content:
@@ -34,7 +36,7 @@ post:
 
 components:
   schemas:
-    PostsListResponseBody:
+    GetPostsResponseBody:
       type: array
       items:
         $ref: './components/post.yaml'

--- a/web-api-designs/web-practice-tech/paths/posts/post.yaml
+++ b/web-api-designs/web-practice-tech/paths/posts/post.yaml
@@ -10,9 +10,27 @@ get:
     "200":
       description: Successful response
       content:
-        "application/json":
+        application/json:
           schema:
             $ref: "#/components/schemas/PostsListResponseBody"
+
+post:
+  summary: 投稿を登録する
+  description: N/A
+  tags: [Users]
+  operationId: createPost
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "#/components/schemas/CreatePostRequestBody"
+  responses:
+    "200":
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CreatePostResponseBody"
 
 components:
   schemas:
@@ -20,3 +38,20 @@ components:
       type: array
       items:
         $ref: './components/post.yaml'
+
+    CreatePostRequestBody:
+          type: object
+          properties:
+            id:
+              type: integer
+            userId:
+              type: integer
+            title:
+              type: string
+            completed:
+              type: string
+
+    CreatePostResponseBody:
+          type: array
+          items:
+            $ref: './components/post.yaml'

--- a/web-api-designs/web-practice-tech/paths/posts/post__post-id.yaml
+++ b/web-api-designs/web-practice-tech/paths/posts/post__post-id.yaml
@@ -14,11 +14,80 @@ get:
     "200":
       description: Successful response
       content:
-        "application/json":
+        application/json:
           schema:
             $ref: "#/components/schemas/PostResponseBody"
+
+put:
+  summary: 指定されたIDの投稿を更新する.
+  description: N/A
+  tags: [Posts]
+  operationId: updatePost
+  parameters:
+    - name: postId
+      in: path
+      required: true
+      schema:
+        type: string
+        examle: 1
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "#/components/schemas/UpdatePostRequestBody"
+
+  responses:
+    "200":
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/UpdatePostResponseBody"
+
+delete:
+  summary: 指定されたIDの投稿を削除する.
+  description: N/A
+  tags: [Posts]
+  operationId: deletePost
+  parameters:
+    - name: postId
+      in: path
+      required: true
+      schema:
+        type: string
+        examle: 1
+
+  responses:
+    "200":
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DeletePostResponseBody"
 
 components:
   schemas:
     PostResponseBody:
       $ref: './components/post.yaml'
+
+    UpdatePostRequestBody:
+      type: object
+      properties:
+        id:
+          type: integer
+        userId:
+          type: integer
+        title:
+          type: string
+        completed:
+          type: string
+
+    UpdatePostResponseBody:
+      type: array
+      items:
+        $ref: './components/post.yaml'
+
+    DeletePostResponseBody:
+      type: object
+      properties:
+        {}

--- a/web-api-designs/web-practice-tech/paths/posts/post__post-id.yaml
+++ b/web-api-designs/web-practice-tech/paths/posts/post__post-id.yaml
@@ -1,8 +1,9 @@
 get:
   summary: 指定されたIDの投稿を取得する.
   description: N/A
-  tags: [Posts]
-  operationId: getPostDetail
+  tags:
+    - posts
+  operationId: getPost
   parameters:
     - name: postId
       in: path
@@ -16,12 +17,13 @@ get:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/PostResponseBody"
+            $ref: "#/components/schemas/GetPostResponseBody"
 
 put:
   summary: 指定されたIDの投稿を更新する.
   description: N/A
-  tags: [Posts]
+  tags:
+    - posts
   operationId: updatePost
   parameters:
     - name: postId
@@ -47,7 +49,8 @@ put:
 delete:
   summary: 指定されたIDの投稿を削除する.
   description: N/A
-  tags: [Posts]
+  tags:
+    - posts
   operationId: deletePost
   parameters:
     - name: postId
@@ -67,7 +70,7 @@ delete:
 
 components:
   schemas:
-    PostResponseBody:
+    GetPostResponseBody:
       $ref: './components/post.yaml'
 
     UpdatePostRequestBody:

--- a/web-api-designs/web-practice-tech/paths/posts/post__post-id__comment.yaml
+++ b/web-api-designs/web-practice-tech/paths/posts/post__post-id__comment.yaml
@@ -14,7 +14,7 @@ get:
     "200":
       description: Successful response
       content:
-        "application/json":
+        application/json:
           schema:
             $ref: "#/components/schemas/PostDetailCommentListResponseBody"
 

--- a/web-api-designs/web-practice-tech/paths/posts/post__post-id__comment.yaml
+++ b/web-api-designs/web-practice-tech/paths/posts/post__post-id__comment.yaml
@@ -1,8 +1,9 @@
 get:
   summary: 指定されたIDの投稿のコメントを取得する.
   description: N/A
-  tags: [Posts]
-  operationId: getPostDetailCommentList
+  tags:
+    - posts
+  operationId: getPostComments
   parameters:
     - name: postId
       in: path
@@ -16,11 +17,11 @@ get:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/PostDetailCommentListResponseBody"
+            $ref: "#/components/schemas/GetPostCommentsResponseBody"
 
 components:
   schemas:
-    PostDetailCommentListResponseBody:
+    GetPostCommentsResponseBody:
       type: array
       items:
         type: object

--- a/web-api-designs/web-practice-tech/paths/users/user.yaml
+++ b/web-api-designs/web-practice-tech/paths/users/user.yaml
@@ -1,23 +1,45 @@
 get:
+  ## Rule: 必ず簡潔に何かを書く
   summary: すべてのユーザを返却する
+
+  ## Rule: ドメイン知識となるようなものを書く
   description: |-
     hogeに管理された投稿をすべて返却する.
     ドメイン知識どうのこうの、あれこれ、それそれで、使われているので、
     こうこうそれそれなので、このエンドポイントを削除することは、不可能.
-  tags: [Users]
-  operationId: getUserList
+
+  ## Rule: どのリソースに紐づくかを必須
+  tags:
+    - users
+  ## Rule: フロントのメソッド名に使われるので、いくつかルールを取り入れる
+  ## 1. RESTベース
+  ##      - getUsers
+  ##      - getUser
+  ##      - createUser
+  ##      - updateUser
+  ##      - deleteUser
+  ## リソースベースで基本形に沿ってやる.
+  ##
+  ## 2. ユースケースベース
+  ##      - PUT /users/agree-rule => agreeToTermsForUser
+  ##      - POST /users/update-password => updateUserPassword
+  ##      - POST /daily-flow/{dailyFlowId}/jobs/create => bulkLinkJobsAndDailyFlow
+  ## 特定のケースは、メソッド名を考えてもらうように設計してもらうでよさそう
+  ## あえてゆるさを取り入れることで、変な迷いをなくした（= ルールの例外にぶち当たった時みたいな）
+  operationId: getUsers
   responses:
     "200":
       description: Successful response
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/UserListResponseBody"
+            $ref: "#/components/schemas/GetUsersResponseBody"
 
 post:
   summary: ユーザを登録する
   description: N/A
-  tags: [Users]
+  tags:
+    - users
   operationId: createUser
   requestBody:
     content:
@@ -34,7 +56,7 @@ post:
 
 components:
   schemas:
-    UserListResponseBody:
+    GetUsersResponseBody:
       type: array
       items:
         $ref: './components/user.yaml'

--- a/web-api-designs/web-practice-tech/paths/users/user.yaml
+++ b/web-api-designs/web-practice-tech/paths/users/user.yaml
@@ -10,13 +10,91 @@ get:
     "200":
       description: Successful response
       content:
-        "application/json":
+        application/json:
           schema:
             $ref: "#/components/schemas/UserListResponseBody"
+
+post:
+  summary: ユーザを登録する
+  description: N/A
+  tags: [Users]
+  operationId: createUser
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "#/components/schemas/CreateUserRequestBody"
+  responses:
+    "200":
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/CreateUserResponseBody"
 
 components:
   schemas:
     UserListResponseBody:
+      type: array
+      items:
+        $ref: './components/user.yaml'
+
+    CreateUserRequestBody:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+        username:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+        address:
+          type: object
+          properties:
+            street:
+              type: string
+              nullable: true
+            suite:
+              type: string
+              nullable: true
+            city:
+              type: string
+              nullable: true
+            zipcode:
+              type: string
+              nullable: true
+            geo:
+              type: object
+              properties:
+                lat:
+                  type: string
+                  nullable: true
+                lon:
+                  type: string
+                  nullable: true
+        phone:
+          type: string
+          nullable: true
+        website:
+          type: string
+          nullable: true
+        company:
+          type: object
+          properties:
+            name:
+              type: string
+              nullable: true
+            catchPhrase:
+              type: string
+              nullable: true
+            bs:
+              type: string
+              nullable: true
+
+    CreateUserResponseBody:
       type: array
       items:
         $ref: './components/user.yaml'

--- a/web-api-designs/web-practice-tech/paths/users/user__user-id.yaml
+++ b/web-api-designs/web-practice-tech/paths/users/user__user-id.yaml
@@ -1,8 +1,9 @@
 get:
   summary: 指定されたIDのユーザを取得する.
   description: N/A
-  tags: [Users]
-  operationId: getUserDetail
+  tags:
+    - users
+  operationId: getUser
   parameters:
     - name: userId
       in: path
@@ -16,12 +17,13 @@ get:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/UserResponseBody"
+            $ref: "#/components/schemas/GetUserResponseBody"
 
 put:
   summary: 指定されたIDのユーザを更新する.
   description: N/A
-  tags: [Users]
+  tags:
+    - users
   operationId: updateUser
   parameters:
     - name: userId
@@ -47,7 +49,8 @@ put:
 delete:
   summary: 指定されたIDのユーザを削除する.
   description: N/A
-  tags: [Users]
+  tags:
+    - users
   operationId: deleteUser
   parameters:
     - name: userId
@@ -67,7 +70,7 @@ delete:
 
 components:
   schemas:
-    UserResponseBody:
+    GetUserResponseBody:
       $ref: './components/user.yaml'
 
     UpdateUserRequestBody:

--- a/web-api-designs/web-practice-tech/paths/users/user__user-id.yaml
+++ b/web-api-designs/web-practice-tech/paths/users/user__user-id.yaml
@@ -14,11 +14,123 @@ get:
     "200":
       description: Successful response
       content:
-        "application/json":
+        application/json:
           schema:
             $ref: "#/components/schemas/UserResponseBody"
+
+put:
+  summary: 指定されたIDのユーザを更新する.
+  description: N/A
+  tags: [Users]
+  operationId: updateUser
+  parameters:
+    - name: userId
+      in: path
+      required: true
+      schema:
+        type: string
+        examle: 1
+  requestBody:
+    content:
+      application/json:
+        schema:
+          $ref: "#/components/schemas/UpdateUserRequestBody"
+
+  responses:
+    "200":
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/UpdateUserResponseBody"
+
+delete:
+  summary: 指定されたIDのユーザを削除する.
+  description: N/A
+  tags: [Users]
+  operationId: deleteUser
+  parameters:
+    - name: userId
+      in: path
+      required: true
+      schema:
+        type: string
+        examle: 1
+
+  responses:
+    "200":
+      description: Successful response
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/DeleteUserResponseBody"
 
 components:
   schemas:
     UserResponseBody:
       $ref: './components/user.yaml'
+
+    UpdateUserRequestBody:
+      type: object
+      properties:
+        name:
+          type: string
+          nullable: true
+        username:
+          type: string
+          nullable: true
+        email:
+          type: string
+          nullable: true
+        address:
+          type: object
+          properties:
+            street:
+              type: string
+              nullable: true
+            suite:
+              type: string
+              nullable: true
+            city:
+              type: string
+              nullable: true
+            zipcode:
+              type: string
+              nullable: true
+            geo:
+              type: object
+              properties:
+                lat:
+                  type: string
+                  nullable: true
+                lon:
+                  type: string
+                  nullable: true
+        phone:
+          type: string
+          nullable: true
+        website:
+          type: string
+          nullable: true
+        company:
+          type: object
+          properties:
+            name:
+              type: string
+              nullable: true
+            catchPhrase:
+              type: string
+              nullable: true
+            bs:
+              type: string
+              nullable: true
+
+    UpdateUserResponseBody:
+      type: array
+      items:
+        $ref: './components/user.yaml'
+
+    DeleteUserResponseBody:
+      type: object
+      properties:
+        {}

--- a/web-api-designs/web-practice-tech/paths/users/user__user-id__comment.yaml
+++ b/web-api-designs/web-practice-tech/paths/users/user__user-id__comment.yaml
@@ -14,7 +14,7 @@ get:
     "200":
       description: Successful response
       content:
-        "application/json":
+        application/json:
           schema:
             $ref: "#/components/schemas/UserDetailCommentListResponseBody"
 

--- a/web-api-designs/web-practice-tech/paths/users/user__user-id__comment.yaml
+++ b/web-api-designs/web-practice-tech/paths/users/user__user-id__comment.yaml
@@ -1,8 +1,9 @@
 get:
   summary: 指定されたIDのユーザのコメントを取得する.
   description: N/A
-  tags: [Users]
-  operationId: getUserDetailCommentList
+  tags:
+    - users
+  operationId: getUserComments
   parameters:
     - name: userId
       in: path
@@ -16,11 +17,11 @@ get:
       content:
         application/json:
           schema:
-            $ref: "#/components/schemas/UserDetailCommentListResponseBody"
+            $ref: "#/components/schemas/GetUserCommentsResponseBody"
 
 components:
   schemas:
-    UserDetailCommentListResponseBody:
+    GetUserCommentsResponseBody:
       type: array
       items:
         type: object


### PR DESCRIPTION
## Conclusion
- OpenAPIの書き方をOrvalフレンドリーに設計する
  1. RESTベース
      - GET /users => getUsers
      - GET /users/1 => getUser
      - POST /users => createUser
      - PUT /users => updateUser
      - DELETE /users => deleteUser
  2. ユースケースベース
      - PUT /users/agree-rule => agreeToTermsForUser
      - POST /users/update-password => updateUserPassword
      - POST /daily-flow/{dailyFlowId}/jobs/create => bulkLinkJobsAndDailyFlow
  - 上記の設計パターンで問題が出たら考える
- orvalの出力先の見直し
  - 出力先を `src/__generated__` へ変更
  - さらに、 `api.shchema.ts` に命名を変更

## Other
- UIレイヤーが複数のエンドポイントのデータから表現する場合、hooksの扱いをどうするか問題
- リポジトリがクラサバで分離しているので、どうがっちゃんこしていくか