### PR TITLE
テストの構成を変更＋selectのロジックで副作用が起きないようにする

### DIFF
--- a/src/screens/app-router/tanstack/__test__/mockData.ts
+++ b/src/screens/app-router/tanstack/__test__/mockData.ts
@@ -1,1 +1,0 @@
-export { mockPosts } from '@/__mocks__/posts';

--- a/src/screens/app-router/tanstack/__test__/useGetPostList.test.ts
+++ b/src/screens/app-router/tanstack/__test__/useGetPostList.test.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { getPosts } from '@/__generated__/posts/posts';
 import { _postFilter } from '../useGetPostList';
 import MockAdapter from 'axios-mock-adapter';
-import { mockPosts } from './mockData';
+import { mockPosts } from '@/__mocks__/posts';
 
 describe('_postFilter', () => {
   it('受け取ったデータを正しくフィルタリングできていること', async () => {

--- a/src/screens/app-router/tanstack/index.tsx
+++ b/src/screens/app-router/tanstack/index.tsx
@@ -3,18 +3,18 @@
 import { useGetPostList } from './useGetPostList';
 
 export const TanstackScreen = () => {
-  const { data, error, isPending } = useGetPostList();
-
+  const { data: response, error, isPending } = useGetPostList();
   console.log(`中身`);
-  console.log(data);
+  console.log(response?.data);
 
   if (isPending) return <>ローディング</>;
   if (error) return <>エラーです</>;
+  if (response.status == 404) return <>404</>;
 
   return (
     <>
       <div>データの取得結果</div>
-      {data && data?.map((el) => <div key={el.id}>{el.title}</div>)}
+      {response.data && response.data?.map((el) => <div key={el.id}>{el.title}</div>)}
       {/* <button
         onClick={() => {
           mutation.mutate({

--- a/src/screens/app-router/tanstack/useGetPostList.ts
+++ b/src/screens/app-router/tanstack/useGetPostList.ts
@@ -3,9 +3,9 @@ import { useGetPosts, GetPostsQueryResult } from '@/__generated__/posts/posts';
 
 // NOTE: API取得後のロジック、ここをテストコード書けばよいだけにしておきたい.
 //       さらに、selectorなロジックは別ファイルに切り出すか・・・？
-const _postFilter = (response: GetPostsQueryResult): GetPostsResponseBody => {
+const _postFilter = (response: GetPostsQueryResult): GetPostsQueryResult => {
   const data: GetPostsResponseBody = response.data;
-  return data.map(({ id, title, userId, completed }) => {
+  response.data = data.map(({ id, title, userId, completed }) => {
     return {
       id,
       title: title.toUpperCase(),
@@ -13,6 +13,7 @@ const _postFilter = (response: GetPostsQueryResult): GetPostsResponseBody => {
       completed,
     };
   });
+  return response;
 };
 
 const useGetPostList = () => {


### PR DESCRIPTION
## Conclusion
- selectでは、responseの形式は崩さない
- mockは、RESTにおいては、co-locationに合わない気がしたので、中央管理する

## Other
UI層で、AxiosResponseを受けるときに、 `data.data` となってしまう問題を分割代入でうまく解決できないがわかってない