### PR TITLE
インテグレーションテストの検証＋jest.config.tsの修正

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,11 @@ const config: Config = {
   testEnvironment: 'jsdom',
   // Add more setup options before each test is run
   // setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    // aliasを定義 （tsconfig.jsonのcompilerOptions>pathsの定義に合わせる）
+    // '@/*': ['./src/*'],
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 };
 
 // createJestConfig is exported this way to ensure that next/jest can load the Next.js config which is async

--- a/src/screens/TanstackScreen/__test__/index.test.tsx
+++ b/src/screens/TanstackScreen/__test__/index.test.tsx
@@ -1,0 +1,60 @@
+// Integrationテスト（画面レベルでのテストで担保したい箇所だけを書く）
+
+import axios from 'axios';
+import MockAdapter from 'axios-mock-adapter';
+import { mockPosts } from '@/__mocks__/posts';
+
+import { TanstackScreen } from '..';
+import { render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import AxiosProvider from '@/providers/AxiosProvider';
+import TanstackQueryProvider from '@/providers/TanstackQueryProvider';
+
+describe('Tanstack screen', () => {
+  describe('waitForを使って表現した場合', () => {
+    it('データ取得ができていること', async () => {
+      const mock = new MockAdapter(axios);
+      mock.onGet('/posts').reply(200, mockPosts);
+
+      render(
+        <AxiosProvider>
+          <TanstackQueryProvider>
+            <TanstackScreen />
+          </TanstackQueryProvider>
+        </AxiosProvider>,
+      );
+
+      await waitFor(() => {
+        const actual = screen.getByText('POST ONE');
+        expect(actual).toBeInTheDocument();
+      });
+    });
+  });
+
+  // TODO: （挙動だけみると）うまくモックできてない？
+  xdescribe('データ取得部分をモックした場合', () => {
+    it('データ取得ができていること', async () => {
+      const mock = new MockAdapter(axios);
+      mock.onGet('/posts').reply(200, mockPosts);
+
+      jest.mock('@/__generated_REST__/posts/posts', () => ({
+        useGetPosts: jest.fn(() => ({
+          data: mockPosts,
+          isPending: false,
+          error: false,
+        })),
+      }));
+
+      render(
+        <AxiosProvider>
+          <TanstackQueryProvider>
+            <TanstackScreen />
+          </TanstackQueryProvider>
+        </AxiosProvider>,
+      );
+
+      const actual = await screen.getByText('POST ONE');
+      expect(actual).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Conclusion
- waitForを使って非同期処理の部分は対応した
  - Flakyなテストになりそうな気がしている
- そもそも非同期処理の関数をモックするテストも書いた
  - が、うまく動かないけどコミット
- jestのconfigにmoduleNameMapperを追加
  - jestファイルで、Aliasの呼び出し解決が必要なため

## Other
フロントでのコンポーネントのテストの非同期の箇所は、どっちが一般的な実装なのかは論点。
waitForでいいならそれでもいい。
そうでない場合は、データ取得のようなhooks自体をモックすればいいと思う。
ただうまく行ってない

