### PR TITLE
Global Stateの管理にJotaiの導入

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^1.6.7",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "jotai": "^2.6.4",
     "lucide-react": "^0.312.0",
     "next": "14.0.4",
     "react": "^18",

--- a/src/app/app-router/counter-2/page.tsx
+++ b/src/app/app-router/counter-2/page.tsx
@@ -1,0 +1,5 @@
+import { Counter2Screen } from '@/screens/Counter2Screen';
+
+export default function Counter2Page() {
+  return <Counter2Screen />;
+}

--- a/src/app/app-router/counter/page.tsx
+++ b/src/app/app-router/counter/page.tsx
@@ -1,0 +1,5 @@
+import { CounterScreen } from '@/screens/CounterScreen';
+
+export default function CounterPage() {
+  return <CounterScreen />;
+}

--- a/src/app/app-router/layout.tsx
+++ b/src/app/app-router/layout.tsx
@@ -1,10 +1,13 @@
 import AxiosProvider from '@/providers/AxiosProvider';
 import TanstackQueryProvider from '@/providers/TanstackQueryProvider';
+import JotaiProvider from '@/providers/JotaiProvider';
 
 export default function AppRouterLayout({ children }: { children: React.ReactNode }) {
   return (
     <AxiosProvider>
-      <TanstackQueryProvider>{children}</TanstackQueryProvider>
+      <JotaiProvider>
+        <TanstackQueryProvider>{children}</TanstackQueryProvider>
+      </JotaiProvider>
     </AxiosProvider>
   );
 }

--- a/src/hooks/stores/useCounter.ts
+++ b/src/hooks/stores/useCounter.ts
@@ -1,0 +1,15 @@
+import { useAtom } from 'jotai';
+import { counterAtom } from '@/stores/counterAtom';
+
+export const useCounter = () => {
+  const [count, setCount] = useAtom(counterAtom);
+
+  const increment = () => setCount((c) => c + 1);
+  const decrement = () => setCount((c) => c - 1);
+
+  return {
+    count,
+    increment,
+    decrement,
+  };
+};

--- a/src/providers/JotaiProvider.tsx
+++ b/src/providers/JotaiProvider.tsx
@@ -1,0 +1,7 @@
+'use client';
+
+import { Provider } from 'jotai';
+
+export default function JotaiProvider({ children }: { children: React.ReactNode }) {
+  return <Provider>{children}</Provider>;
+}

--- a/src/screens/Counter2Screen/index.tsx
+++ b/src/screens/Counter2Screen/index.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { WrapLink } from '@/components/shared/WrapLink';
+import { useCounter } from '@/hooks/stores/useCounter';
+
+export const Counter2Screen = () => {
+  const { count, increment, decrement } = useCounter();
+
+  return (
+    <>
+      <h1>カウンター2ページ</h1>
+      <p>現在のカウント: {count}</p>
+      <div>
+        <button onClick={increment}>increment button</button>
+      </div>
+      <div>
+        <button onClick={decrement}>decrement button</button>
+      </div>
+      <WrapLink href='/app-router/counter'>カウンターページへ</WrapLink>
+    </>
+  );
+};

--- a/src/screens/CounterScreen/index.tsx
+++ b/src/screens/CounterScreen/index.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+import { WrapLink } from '@/components/shared/WrapLink';
+import { useCounter } from '@/hooks/stores/useCounter';
+
+export const CounterScreen = () => {
+  const { count, increment, decrement } = useCounter();
+
+  return (
+    <>
+      <h1>カウンターページ</h1>
+      <p>現在のカウント: {count}</p>
+      <div>
+        <button onClick={increment}>increment button</button>
+      </div>
+      <div>
+        <button onClick={decrement}>decrement button</button>
+      </div>
+      <WrapLink href='/app-router/counter-2'>カウンター2ページへ</WrapLink>
+    </>
+  );
+};

--- a/src/stores/counterAtom.ts
+++ b/src/stores/counterAtom.ts
@@ -1,0 +1,3 @@
+import { atom } from 'jotai';
+
+export const counterAtom = atom(0);

--- a/yarn.lock
+++ b/yarn.lock
@@ -4756,6 +4756,11 @@ jiti@^1.19.1:
   resolved "https://registry.yarnpkg.com/jiti/-/jiti-1.21.0.tgz#7c97f8fe045724e136a397f7340475244156105d"
   integrity sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==
 
+jotai@^2.6.4:
+  version "2.6.4"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.6.4.tgz#a68a76f0e5cd2b614afae7112cfc52a77dbfe038"
+  integrity sha512-RniwQPX4893YlNR1muOtyUGHYaTD1fhEN4qnOuZJSrDHj6xdEMrqlRSN/hCm2fshwk78ruecB/P2l+NCVWe6TQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
## Conclusion
- `src/stores/hogeAtom.ts` で1ファイルずつ管理
  - どうせ少ないのでファイル管理でもいいが、1ファイル管理でも全然良い
  - また考えて決める
- `useAtom` をUI層から呼ぶとドメインロジックが、介入してしまうので、hooksでラップした
  - ゆえにUIから見ると、stateとstate操作メソッドをもらって使用するだけというふうになる

## Other
- Tanstackとのインテグレーションがあったりしてもお勧めされているが、メリットが理解できなかったので見送り
  - https://zenn.dev/uniformnext/articles/96cb62fc65c8bd
- まともにドキュメントが読めていないので、便利そうな機能とかは頭に入っていない
- APIのキャッシュをTanstackに任せている以上、あまり登場頻度が高くないと見込んで学習優先度を下げてしまっている