### PR TITLE
生年月日のバリデーションの実装

### DIFF
--- a/src/components/ui/Form/form.tsx
+++ b/src/components/ui/Form/form.tsx
@@ -38,7 +38,6 @@ const FormField = <
 };
 
 const useFormField = () => {
-  debugger;
   const fieldContext = React.useContext(FormFieldContext);
   const itemContext = React.useContext(FormItemContext);
   const { getFieldState, formState } = useFormContext();
@@ -50,9 +49,6 @@ const useFormField = () => {
   }
 
   const { id } = itemContext;
-
-  console.log(`fieldContext: ${JSON.stringify(fieldContext)}`);
-  console.log(`itemContext: ${JSON.stringify(itemContext)}`);
 
   return {
     id,
@@ -139,7 +135,6 @@ const FormMessage = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
-  debugger;
   const { error, formMessageId } = useFormField();
   const body = error ? String(error?.message) : children;
 

--- a/src/components/ui/Form/form.tsx
+++ b/src/components/ui/Form/form.tsx
@@ -38,6 +38,7 @@ const FormField = <
 };
 
 const useFormField = () => {
+  debugger;
   const fieldContext = React.useContext(FormFieldContext);
   const itemContext = React.useContext(FormItemContext);
   const { getFieldState, formState } = useFormContext();
@@ -49,6 +50,9 @@ const useFormField = () => {
   }
 
   const { id } = itemContext;
+
+  console.log(`fieldContext: ${JSON.stringify(fieldContext)}`);
+  console.log(`itemContext: ${JSON.stringify(itemContext)}`);
 
   return {
     id,
@@ -135,6 +139,7 @@ const FormMessage = React.forwardRef<
   HTMLParagraphElement,
   React.HTMLAttributes<HTMLParagraphElement>
 >(({ className, children, ...props }, ref) => {
+  debugger;
   const { error, formMessageId } = useFormField();
   const body = error ? String(error?.message) : children;
 

--- a/src/screens/ApplyScreen/ApplyForm/index.tsx
+++ b/src/screens/ApplyScreen/ApplyForm/index.tsx
@@ -16,19 +16,8 @@ type Props = {
 
 export const ApplyForm = ({ id }: Props) => {
   // const { data } = useQuarificationQuery();
-  const data: {
-    ans: {
-      id: number;
-      name: string;
-      required: boolean;
-    }[];
-    apo: {
-      id: number;
-      name: string;
-      required: boolean;
-    }[];
-  } = {
-    ans: [
+  let apiData = {
+    qualificationData: [
       {
         id: 1,
         name: '看護師',
@@ -45,7 +34,12 @@ export const ApplyForm = ({ id }: Props) => {
         required: false,
       },
     ],
-    apo: [
+    jobCategoryData: {
+      min_age: 0,
+    },
+  };
+  if (id === '2') {
+    apiData.qualificationData = [
       {
         id: 4,
         name: '薬剤師',
@@ -56,17 +50,11 @@ export const ApplyForm = ({ id }: Props) => {
         name: '自動車運転免許',
         required: false,
       },
-    ],
-  };
-
-  type JobCategoryCode = 'ans' | 'apo';
-  let key: JobCategoryCode = 'ans';
-
-  if (id === '2') {
-    key = 'apo';
+    ];
+    apiData.jobCategoryData.min_age = 23;
   }
 
-  const applyFormSchema = createSchema(data[key]);
+  const applyFormSchema = createSchema(apiData);
 
   const forms = useForm<ApplyFormSchemaType>({
     // NOTE: 以下回避のため、デフォルト値を設定する
@@ -76,6 +64,13 @@ export const ApplyForm = ({ id }: Props) => {
       firstName: '',
       familyNameKana: '',
       firstNameKana: '',
+      //
+      // TODO: 初期値に文字列があるので、Zodのシンプルな必須チェックには引っかからない
+      //       が、相関チェックで1つでも空だった場合、生年月日を選択してくださいと出力するので、
+      //       そこでカバーする
+      year: '',
+      month: '',
+      day: '',
       // NOTE: RadixUI側のbugっぽく、回避策が、空文字をdefaultValuesに使うようなことが書いてあった
       // @see: https://github.com/radix-ui/primitives/issues/1808
       // day: '',

--- a/src/screens/ApplyScreen/schemas/index.ts
+++ b/src/screens/ApplyScreen/schemas/index.ts
@@ -25,8 +25,6 @@ const createBasicInformationBaseSchema = () =>
       .max(50, { message: '名前（ふりがな）は50文字以内で入力してください' })
       .regex(/^(?:[ぁ-ゞ]+)*$/, { message: '名前（ふりがな）はひらがなで入力してください' }),
 
-    // TODO: 相関生年月日チェック
-    //       年齢チェック
     year: z.string(),
     month: z.string(),
     day: z.string(),

--- a/src/screens/ApplyScreen/schemas/index.ts
+++ b/src/screens/ApplyScreen/schemas/index.ts
@@ -1,70 +1,71 @@
 import { z } from 'zod';
 
+import { calcAcademicPeriodDate } from '@/utils/days';
+
 const createBasicInformationBaseSchema = () =>
-  z
-    .object({
-      familyName: z
-        .string()
-        // NOTE: min(1)で、必須項目を表現する
-        .min(1, { message: '名字を入力してください' })
-        .max(50, { message: '50文字以内で入力してください' }),
-      firstName: z
-        .string()
-        .min(1, { message: '名前を入力してください' })
-        .max(50, { message: '50文字以内で入力してください' }),
+  z.object({
+    familyName: z
+      .string()
+      // NOTE: min(1)で、必須項目を表現する
+      .min(1, { message: '名字を入力してください' })
+      .max(50, { message: '50文字以内で入力してください' }),
+    firstName: z
+      .string()
+      .min(1, { message: '名前を入力してください' })
+      .max(50, { message: '50文字以内で入力してください' }),
 
-      familyNameKana: z
-        .string()
-        .min(1, { message: '名字（ひらがな）を入力してください' })
-        .max(50, { message: '名字（ふりがな）は50文字以内で入力してください' })
-        .regex(/^(?:[ぁ-ゞ]+)*$/, { message: '名字（ふりがな）はひらがなで入力してください' }),
-      firstNameKana: z
-        .string()
-        .min(1, { message: '名前（ひらがな）を入力してください' })
-        .max(50, { message: '名前（ふりがな）は50文字以内で入力してください' })
-        .regex(/^(?:[ぁ-ゞ]+)*$/, { message: '名前（ふりがな）はひらがなで入力してください' }),
+    familyNameKana: z
+      .string()
+      .min(1, { message: '名字（ひらがな）を入力してください' })
+      .max(50, { message: '名字（ふりがな）は50文字以内で入力してください' })
+      .regex(/^(?:[ぁ-ゞ]+)*$/, { message: '名字（ふりがな）はひらがなで入力してください' }),
+    firstNameKana: z
+      .string()
+      .min(1, { message: '名前（ひらがな）を入力してください' })
+      .max(50, { message: '名前（ふりがな）は50文字以内で入力してください' })
+      .regex(/^(?:[ぁ-ゞ]+)*$/, { message: '名前（ふりがな）はひらがなで入力してください' }),
 
-      // TODO: 相関生年月日チェック
-      //       年齢チェック
-      year: z.string().min(1, { message: '生年月日を選択してください' }),
-      month: z.string().min(1, { message: '生年月日を選択してください' }),
-      day: z.string().min(1, { message: '生年月日を選択してください' }),
+    // TODO: 相関生年月日チェック
+    //       年齢チェック
+    year: z.string(),
+    month: z.string(),
+    day: z.string(),
 
-      gender: z.coerce.number().min(1, { message: '性別を選択してください' }),
+    // gender: z.coerce.number().min(1, { message: '性別を選択してください' }),
 
-      // TODO: 電話番号フォーマットチェック
-      tel: z.string().min(1, { message: '電話番号を入力してください' }),
+    // // TODO: 電話番号フォーマットチェック
+    // tel: z.string().min(1, { message: '電話番号を入力してください' }),
 
-      // TODO: 正しい郵便番号チェック
-      //       郵便番号が見つからないチェック（API）
-      postalCode: z.string(),
-      prefectureId: z.string().min(1, { message: '都道府県を選択してください' }),
-      cityId: z.string().min(1, { message: '市区町村を選択してください' }),
-      town: z.string().max(100, { message: '町名・番地は100文字以内で入力してください' }),
-      building: z.string().max(100, { message: '建物名は100文字以内で入力してください' }),
+    // // TODO: 正しい郵便番号チェック
+    // //       郵便番号が見つからないチェック（API）
+    // postalCode: z.string(),
+    // prefectureId: z.string().min(1, { message: '都道府県を選択してください' }),
+    // cityId: z.string().min(1, { message: '市区町村を選択してください' }),
+    // town: z.string().max(100, { message: '町名・番地は100文字以内で入力してください' }),
+    // building: z.string().max(100, { message: '建物名は100文字以内で入力してください' }),
 
-      // TODO: メールアドレスフォーマットチェック
-      //       登録済みかどうかチェック
-      email: z
-        .string()
-        .min(1, { message: 'メールアドレスを入力してください' })
-        .max(100, { message: '100文字以内で入力してください' }),
+    // // TODO: メールアドレスフォーマットチェック
+    // //       登録済みかどうかチェック
+    // email: z
+    //   .string()
+    //   .min(1, { message: 'メールアドレスを入力してください' })
+    //   .max(100, { message: '100文字以内で入力してください' }),
 
-      password: z.string().min(8, { message: '8文字以上のパスワードを入力してください' }),
-      employmentStatus: z.number().min(1, { message: '就業状況を選択してください' }),
-    })
-    .required({
-      familyName: true,
-      firstName: true,
-      familyNameKana: true,
-      firstNameKana: true,
-      gender: true,
-      tel: true,
-      postalCode: true,
-      prefecture: true,
-      city: true,
-      employmentStatus: true,
-    });
+    // password: z.string().min(8, { message: '8文字以上のパスワードを入力してください' }),
+    // employmentStatus: z.number().min(1, { message: '就業状況を選択してください' }),
+  });
+// .required({
+//   familyName: true,
+//   firstName: true,
+//   familyNameKana: true,
+//   firstNameKana: true,
+//   gender: true,
+//   tel: true,
+//   postalCode: true,
+//   prefecture: true,
+//   city: true,
+//   employmentStatus: true,
+// });
 
 export type BasicInformationSchemaType = z.infer<
   ReturnType<typeof createBasicInformationBaseSchema>
@@ -72,8 +73,7 @@ export type BasicInformationSchemaType = z.infer<
 
 const createApplyInformationBaseSchema = () =>
   z.object({
-    memberCareer: z.string().min(1, { message: '経験年数を選択してください' }),
-
+    // memberCareer: z.string().min(1, { message: '経験年数を選択してください' }),
     // TODO: 面接希望日時（行追加のネスト）あとで
     // prefferdDateTime: z.array(
     //   z.object({
@@ -86,11 +86,7 @@ const createApplyInformationBaseSchema = () =>
 
 const attachApplyInformationDynamicSchema = (
   applyInformationBaseSchema: ReturnType<typeof createApplyInformationBaseSchema>,
-  qualifications: {
-    id: number;
-    name: string;
-    required: boolean;
-  }[],
+  qualifications: Props['qualificationData'],
 ) => {
   //
   // TODO: 多分動的だけど、refineで表現するしかなさそうな気がしたので、いったんコメントアウトする
@@ -113,7 +109,7 @@ const attachApplyInformationDynamicSchema = (
 
   return applyInformationBaseSchema.merge(
     z.object({
-      qualifications: z.number().array(),
+      qualifications: z.number().array().optional(),
     }),
   );
 };
@@ -129,20 +125,94 @@ const mergeSchema = (
 
 export type ApplyFormSchemaType = z.infer<ReturnType<typeof mergeSchema>>;
 
-const attachBasicInformationValidation = (schema: ReturnType<typeof mergeSchema>) =>
-  schema.refine(
-    (data) => {
-      const { year, month, day } = data;
-      if (year !== null && month !== null && day !== null) {
-        return true;
+const attachBasicInformationValidation = (schema: ReturnType<typeof mergeSchema>, minAge: number) =>
+  //
+  // TODO: superRefineもrefineも、onBlurの挙動ではなくonSubmitで発動するっぽい
+  //       onBlurに設定しても意味ないので、手動で発火させる必要があるかもしれない
+  //
+  schema.superRefine((args, ctx) => {
+    const { year, month, day } = args;
+
+    //
+    // NOTE: 3項目での必須チェック
+    //
+    if (year === '' || month === '' || day === '') {
+      ctx.addIssue({
+        code: z.ZodIssueCode.invalid_date,
+        message: '生年月日をすべて選択してください',
+        path: ['birthday'],
+        //
+        // NOTE: ここのエラーでコケた時に、後続のバリデーションを動作させたくない時に設定する
+        //       その上で、z.NEVER;をreturnしてあげると、後続が実行されずに、
+        //       ここのエラーで終わる
+        // @see: https://zod.dev/?id=abort-early
+        fatal: true,
+      });
+      return z.NEVER;
+    }
+
+    //
+    // NOTE: 必須応募資格の年齢チェック
+    //
+    if (minAge !== 0) {
+      const birthdayPeriod = calcAcademicPeriodDate(+year, +month, +day);
+      const now = new Date();
+      const jobPeriod = calcAcademicPeriodDate(
+        now.getFullYear() + 1 - (minAge + 1),
+        now.getMonth() + 1,
+        now.getDate(),
+      );
+      // NOTE: チェック用途テスト
+      // if (birthdayPeriod <= 20230401) {
+      if (birthdayPeriod <= jobPeriod) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.invalid_date,
+          message: '応募条件を満たす年齢に達していません',
+          path: ['birthday'],
+        });
       }
-      return false;
-    },
-    {
-      message: '生年月日をすべて選択してください',
-      path: ['birthDay'],
-    },
-  );
+    }
+  });
+
+//
+// NOTE: superRefineのほうが柔軟的、だがこちらのほうがシンプル
+//
+// schema
+//   .refine(
+//     ({ year, month, day }) => {
+//       if (year === '' || month === '' || day === '') {
+//         return false;
+//       }
+//       return true;
+//     },
+//     {
+//       message: '生年月日をすべて選択してください',
+//       path: ['birthday'],
+//     },
+//   )
+//   .refine(
+//     ({ year, month, day }) => {
+//       if (minAge !== 0) {
+//         const birthdayPeriod = calcAcademicPeriodDate(+year, +month, +day);
+//         const now = new Date();
+//         const jobPeriod = calcAcademicPeriodDate(
+//           now.getFullYear() + 1 - (minAge + 1),
+//           now.getMonth() + 1,
+//           now.getDate(),
+//         );
+//         // NOTE: チェック用途テスト
+//         if (birthdayPeriod <= 20230401) {
+//           // if (birthdayPeriod <= jobPeriod) {
+//           return false;
+//         }
+//       }
+//       return true;
+//     },
+//     {
+//       message: '応募条件を満たす年齢に達していません',
+//       path: ['birthday'],
+//     },
+//   );
 
 // const attachApplyInformationValidation = (schema: ReturnType<typeof mergeSchema>) =>
 //   schema.refine(
@@ -160,18 +230,22 @@ const attachBasicInformationValidation = (schema: ReturnType<typeof mergeSchema>
 //     },
 //   );
 
+type Props = {
+  qualificationData: {
+    id: number;
+    name: string;
+    required: boolean;
+  }[];
+  jobCategoryData: {
+    min_age: number;
+  };
+};
 //
 // NOTE: エントリーポイント.
 //       可変項目のスキーマの動的生成と追加
 //       テクいフォームだと、だいたいこの構造になるか
 //
-export const createSchema = (
-  qualifications: {
-    id: number;
-    name: string;
-    required: boolean;
-  }[] = [],
-) => {
+export const createSchema = (apiData: Props) => {
   //
   // NOTE: STEP1. フォームをコンポーネントごとに分割した単位でベースのスキーマを作成する
   //              ベースのスキーマとは、可変ではない項目を指す.
@@ -186,7 +260,7 @@ export const createSchema = (
   //
   const applyInformationSchema = attachApplyInformationDynamicSchema(
     applyInformationBaseSchema,
-    qualifications,
+    apiData.qualificationData,
   );
 
   //
@@ -194,14 +268,14 @@ export const createSchema = (
   //              これは対象フォーム全体のベーススキーマを表す
   //              Zodの型の問題で先に項目のマージを優先する.
   //
-  const schema = mergeSchema(basicInformationBaseSchema, applyInformationSchema);
+  const mergedSchema = mergeSchema(basicInformationBaseSchema, applyInformationSchema);
 
   //
   // NOTE: STEP4. 基本系以外のバリデーションを付与する
   //              例えば、相関チェック.
   //              生年月日が3項目である時、相関的にチェックが必要な場合を指す
   //
-  attachBasicInformationValidation(schema);
+  const schema = attachBasicInformationValidation(mergedSchema, apiData.jobCategoryData.min_age);
   // attachApplyInformationValidation(schema);
 
   return schema;

--- a/src/utils/days.ts
+++ b/src/utils/days.ts
@@ -16,4 +16,17 @@ const getDaysInMonth = (year: string | null, month: string | null) => {
       : 31;
 };
 
-export { getDaysInMonth };
+const calcAcademicPeriodDate = (y: number, m: number, d: number) => {
+  let year = +y;
+  const month = +m;
+  const day = +d;
+
+  if (month < 4 || (month === 4 && day === 1)) {
+    year -= 1;
+  }
+
+  // YYYYMMDD
+  return year * 10000 + 400 + 1;
+};
+
+export { getDaysInMonth, calcAcademicPeriodDate };


### PR DESCRIPTION
## Conclusion
- バリデーションは、refineおよびsuperRefineを試して、superRefineで実装した（サンプルはどちらもある）
- defaultValueを設置して、スキーマ側の必須チェックは実質無効化
  - その代わり、カスタムバリデーションで3ヶ所同時の必須チェックを実装
- 独自定義のエラーメッセージの出力方法を力技？で実装
- SelectのonChange時には、RHFのmode: Blurの設定は、refineおよびsuperRefineで指定した `birthday` のキーには効かないので、各自のonChange時に、RHFのtrigger関数を使って毎回、 `birthday` のキーのバリデーションチェックを走らせるようにして、無理やり？実現

## Other
- だいたいやりたいことはできたけどこれで本当に大丈夫かはわからないので、有識者に確認してもらいたい
- カスタムバリデーションだいぶ掴んできたので、同じように実装はやりきれそう