### PR TITLE
refineの書き方を見直して、即時発火するような書き方に修正

### DIFF
--- a/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/index.tsx
+++ b/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/index.tsx
@@ -99,35 +99,33 @@ export const BasicInfomationForm = () => {
         <div className='flex flex-row gap-x-4'>
           <FormField
             control={control}
-            name='year'
+            name='birthday.year'
             render={({ field: { ref, onChange, ...restField } }) => (
               <Select {...restField} onValueChange={handleYearChange}>
                 <SelectTrigger ref={ref} className='w-[180px]'>
                   <SelectValue placeholder='西暦' />
                 </SelectTrigger>
                 <Year />
-                {/* <FormMessage /> */}
               </Select>
             )}
           />
 
           <FormField
             control={control}
-            name='month'
+            name='birthday.month'
             render={({ field: { ref, onChange, ...restField } }) => (
               <Select {...restField} onValueChange={(value) => handleMonthChange(value)}>
                 <SelectTrigger ref={ref} className='w-[180px]'>
                   <SelectValue placeholder='月' />
                 </SelectTrigger>
                 <Month />
-                {/* <FormMessage /> */}
               </Select>
             )}
           />
 
           <FormField
             control={control}
-            name='day'
+            name='birthday.day'
             //
             // NOTE: shadcnuiが作るSelectは、onValueChangeのPropsで待っているので、onChange単体を取り出して、
             //       関数をそのまま渡してあげている
@@ -143,27 +141,23 @@ export const BasicInfomationForm = () => {
                     <SelectValue placeholder='日' />
                   </SelectTrigger>
                   <Day year={selectedYear} month={selectedMonth} />
-                  {/* <FormMessage /> */}
                 </Select>
               );
             }}
           />
         </div>
-        {/* 
-        <FormField
-          //
-          // TODO: カスタムバリデーションのエラーメッセージを
-          //       無理やり表現した結果だが、これでいいのかは、わからない
-          // @ts-ignore
-          name='birthday'
-          render={() => <FormMessage />}
-        /> */}
-        {errors.year?.message ? (
-          <FormField name='year' render={() => <FormMessage />} />
-        ) : errors.month?.message ? (
-          <FormField name='month' render={() => <FormMessage />} />
+
+        {errors.birthday?.year?.message ? (
+          <FormField name='birthday.year' render={() => <FormMessage />} />
+        ) : errors.birthday?.month?.message ? (
+          <FormField name='birthday.month' render={() => <FormMessage />} />
+        ) : errors.birthday?.day?.message ? (
+          <FormField name='birthday.day' render={() => <FormMessage />} />
         ) : (
-          errors.day?.message && <FormField name='day' render={() => <FormMessage />} />
+          // @ts-ignore
+          errors.birthday?.ageIneligible?.message && (
+            <FormField name='birthday.ageIneligible' render={() => <FormMessage />} />
+          )
         )}
       </div>
 

--- a/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/useBasicInformationForm.ts
+++ b/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/useBasicInformationForm.ts
@@ -12,9 +12,9 @@ export const useBasicInformaionForm = () => {
     formState: { errors },
   } = useFormContext<BasicInformationSchemaType>();
 
-  const selectedYear = watch('year');
-  const selectedMonth = watch('month');
-  const selectedDay = watch('day');
+  const selectedYear = watch('birthday.year');
+  const selectedMonth = watch('birthday.month');
+  const selectedDay = watch('birthday.day');
 
   const selectedPrefecture = watch('prefectureId');
   //
@@ -29,17 +29,10 @@ export const useBasicInformaionForm = () => {
   const handleYearChange = (value: string) => {
     // 現在選択されている `日` が、選択されたYear, Monthでの日に存在しない場合
     if (getDaysInMonth(value, selectedMonth) < Number(selectedDay)) {
-      setValue('day', '');
+      setValue('birthday.day', '');
     }
-    setValue('year', value);
-
-    //
-    // TODO: birthdayというキーでエラーを管理しているので、
-    //       生年月日のonChangeで毎回手動でバリデーションチェックする
-    //       refineのpathがbirthdayなので、こういう書き方しかできないかもしれない
-    //
-    // @ts-ignore
-    // trigger('birthday');
+    setValue('birthday.year', value);
+    trigger('birthday');
   };
 
   //
@@ -49,28 +42,15 @@ export const useBasicInformaionForm = () => {
   const handleMonthChange = (value: string) => {
     // 現在選択されている `日` が、選択されたYear, Monthでの日に存在しない場合
     if (getDaysInMonth(selectedYear, value) < Number(selectedDay)) {
-      setValue('day', '');
+      setValue('birthday.day', '');
     }
-    setValue('month', value);
-
-    //
-    // TODO: birthdayというキーでエラーを管理しているので、
-    //       生年月日のonChangeで毎回手動でバリデーションチェックする
-    //       refineのpathがbirthdayなので、こういう書き方しかできないかもしれない
-    //
-    // @ts-ignore
-    // trigger('birthday');
+    setValue('birthday.month', value);
+    trigger('birthday');
   };
 
   const handleDayChange = (value: string) => {
-    setValue('day', value);
-    //
-    // TODO: birthdayというキーでエラーを管理しているので、
-    //       生年月日のonChangeで毎回手動でバリデーションチェックする
-    //       refineのpathがbirthdayなので、こういう書き方しかできないかもしれない
-    //
-    // @ts-ignore
-    // trigger('birthday');
+    setValue('birthday.day', value);
+    trigger('birthday');
   };
 
   const handlePostalCodeChange = async (value: string) => {

--- a/src/screens/ApplyScreen/ApplyForm/index.tsx
+++ b/src/screens/ApplyScreen/ApplyForm/index.tsx
@@ -68,11 +68,11 @@ export const ApplyForm = ({ id }: Props) => {
       // TODO: 初期値に文字列があるので、Zodのシンプルな必須チェックには引っかからない
       //       が、相関チェックで1つでも空だった場合、生年月日を選択してくださいと出力するので、
       //       そこでカバーする
-      year: '',
-      month: '',
-      // NOTE: RadixUI側のbugっぽく、回避策が、空文字をdefaultValuesに使うようなことが書いてあった
-      // @see: https://github.com/radix-ui/primitives/issues/1808
-      day: '',
+      birthday: {
+        year: '',
+        month: '',
+        day: '',
+      },
       //
       // TODO: 初期値がない場合は、これでいいのか？
       //       これしかないと思っているので、明示的に設定


### PR DESCRIPTION
## Conclusion
- Zodのobjectの中身に直接refineを書けば、外側の親のobjectには影響がないので、そのようにrefineを書く
- onChangeの中で、refineを即時に呼び出したいと場合は、triggerを使ってやると発火するようになる
- この書き方でないと、基本的にrefineは、普通のバリデーションがすべてクリアしてから呼ばれるので、onBlurとかでもonSubmitの時に判明してしまう

## Other
- これでまた詰まるようなことが起きたら変更する