### PR TITLE
細かい部分りファクタ

### DIFF
--- a/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/index.tsx
+++ b/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/index.tsx
@@ -26,6 +26,7 @@ export const BasicInfomationForm = () => {
     handleYearChange,
     handleMonthChange,
     handleDayChange,
+    handlePrefectureChange,
     handlePostalCodeChange,
     handleEmailChange,
   } = useBasicInformaionForm();
@@ -159,13 +160,7 @@ export const BasicInfomationForm = () => {
         ) : errors.birthday?.day?.message ? (
           <FormField name='birthday.day' render={() => <FormMessage />} />
         ) : (
-          // @ts-ignore
-          errors.birthday?.ageIneligible?.message && (
-            //
-            // TODO: ts-ignoreが存在してしまうが、意味合い的にわかりやすいpathで設定してみた
-            //
-            <FormField name='birthday.ageIneligible' render={() => <FormMessage />} />
-          )
+          errors.birthday?.message && <FormField name='birthday' render={() => <FormMessage />} />
         )}
       </div>
 
@@ -255,7 +250,7 @@ export const BasicInfomationForm = () => {
           render={({ field: { ref, onChange, ...restField } }) => (
             <FormItem>
               <FormLabel>都道府県</FormLabel>
-              <Select {...restField} onValueChange={onChange}>
+              <Select {...restField} onValueChange={handlePrefectureChange}>
                 <FormControl>
                   <SelectTrigger ref={ref} className='w-[180px]'>
                     <SelectValue placeholder='都道府県' />

--- a/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/useBasicInformationForm.ts
+++ b/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/useBasicInformationForm.ts
@@ -53,6 +53,23 @@ export const useBasicInformaionForm = () => {
     trigger('birthday');
   };
 
+  const handlePrefectureChange = (value: string) => {
+    //
+    // NOTE: ハンドラーを設定した場合は、この2つは必須と考えていい.
+    //       ハンドラーを定義するとRHFのonChangeをオーバーライドしているのと同じなので、
+    //       useFormで指定しているonBlurなどが効いてないみたいな感じとなる.
+    //       ゆえに、setValueとtriggerは必須となる.
+    //
+    setValue('prefectureId', value);
+    trigger('prefectureId');
+
+    //
+    // NOTE: 明示的に空を設定しないと、shadcn/uiのSelectValueが表示されないため
+    //       このハンドラーが必要となる
+    //
+    setValue('cityId', '');
+  };
+
   const handlePostalCodeChange = async (value: string) => {
     setValue('postalCode', value);
 
@@ -79,6 +96,10 @@ export const useBasicInformaionForm = () => {
         // TODO: 外部APIの都合上、自動反映を後回し（watchしているのでリストは作成される）
         //
         // setValue('cityId', cityId);
+
+        trigger('prefectureId');
+        // trigger('cityId');
+        trigger('town');
       }
     }
   };
@@ -102,6 +123,7 @@ export const useBasicInformaionForm = () => {
     handleYearChange,
     handleMonthChange,
     handleDayChange,
+    handlePrefectureChange,
     handlePostalCodeChange,
     handleEmailChange,
   };

--- a/src/screens/ApplyScreen/ApplyForm/index.tsx
+++ b/src/screens/ApplyScreen/ApplyForm/index.tsx
@@ -57,6 +57,7 @@ export const ApplyForm = ({ id }: Props) => {
   const applyFormSchema = createSchema(apiData);
 
   const forms = useForm<ApplyFormSchemaType>({
+    //
     // NOTE: 以下回避のため、デフォルト値を設定する
     // @see: https://react.dev/reference/react-dom/components/input#controlling-an-input-with-a-state-variable
     defaultValues: {
@@ -64,10 +65,6 @@ export const ApplyForm = ({ id }: Props) => {
       firstName: '',
       familyNameKana: '',
       firstNameKana: '',
-      //
-      // TODO: 初期値に文字列があるので、Zodのシンプルな必須チェックには引っかからない
-      //       が、相関チェックで1つでも空だった場合、生年月日を選択してくださいと出力するので、
-      //       そこでカバーする
       birthday: {
         year: '',
         month: '',
@@ -87,8 +84,6 @@ export const ApplyForm = ({ id }: Props) => {
       password: '',
       employmentStatus: undefined,
       memberCareer: '',
-      // TODO: undefinedを初期値とすると、Requiredのエラーがうまく出現するが、空文字だとRequiredの判定をスルーしてしまう
-      //       Warning: A component is changing an uncontrolled input to be controlled. This is likely caused by the value changing from undefined to a defined value, which should not happen. Decide between using a controlled or uncontrolled input element for the lifetime of the component. More info: https://reactjs.org/link/controlled-components
       qualifications: [],
     },
     resolver: zodResolver(applyFormSchema),


### PR DESCRIPTION
## Conclusion
- prefectureのhandlerに市区町村の初期化処理とトリガーの実装
- refineのpathの設定を削除
- 郵便番号のhandlerに都道府県等にトリガーの実装
- 不要になったコメント削除
- schemaのstepの削減
  - BaseSchemaの概念も削除
  - refineは生成時にデータをもらいながらrefineで定義することができたため
- 生年月日を選択してくださいの二重バリデーション実装
  - min＋refineの二重で実装
    - こうしないと1つでも実施された時にrefineの内容がすぐに出てしまう
    - 許容範囲だが、ちょっと変なので実装した