### PR TITLE
名字コンポーネントとスキーマの切り出し

### DIFF
--- a/src/components/ui/Input/FamilyName/index.tsx
+++ b/src/components/ui/Input/FamilyName/index.tsx
@@ -1,0 +1,61 @@
+import { FC } from 'react';
+import { z } from 'zod';
+import { PartialFormValidation } from '@/libs/zod-utils';
+
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/Form/form';
+import { Input } from '@/components/ui/Input/input';
+
+type FamilyNameSchema = {
+  familyName: string;
+};
+
+const familyNameDefaultValidation: PartialFormValidation<FamilyNameSchema> = {
+  familyName: z
+    .string()
+    .min(1, { message: '名字を入力してください' })
+    .max(50, { message: '50文字以内で入力してください' }),
+};
+
+//
+// NOTE: この画面では、必須、必須ではないみたいなものに対応するために、
+//       一律でexportするのは関数とした.
+//
+const generateFamilyNameValidation = (isRequired: boolean = true) => {
+  const familyNameValidation = isRequired
+    ? familyNameDefaultValidation
+    : {
+        familyName: z.string().max(50, { message: '50文字以内で入力してください' }),
+      };
+  return familyNameValidation;
+};
+
+type Props = {
+  control: any;
+};
+const FamilyName: FC<Props> = ({ control }) => {
+  return (
+    <FormField
+      control={control}
+      name='familyName'
+      render={({ field }) => (
+        <FormItem className='flex-1'>
+          <FormLabel>名字</FormLabel>
+          <FormControl>
+            <Input placeholder='山田' {...field} />
+          </FormControl>
+          <FormDescription>ここは説明箇所です.</FormDescription>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};
+
+export { FamilyName, generateFamilyNameValidation };

--- a/src/libs/zod-utils.ts
+++ b/src/libs/zod-utils.ts
@@ -1,0 +1,3 @@
+import { z } from 'zod';
+
+export type PartialFormValidation<T> = { [key in keyof T]: z.ZodSchema<T[key]> };

--- a/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/index.tsx
+++ b/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/index.tsx
@@ -15,6 +15,7 @@ import { Day } from '@/components/ui/Select/Birthday/day';
 import { Prefecture } from '@/components/ui/Select/Prefecture';
 import { CityWrapper } from '@/screens/ApplyScreen/ApplyForm/BasicInformationForm/CityWrapper';
 import { useBasicInformaionForm } from '@/screens/ApplyScreen/ApplyForm/BasicInformationForm/useBasicInformationForm';
+import { FamilyName } from '@/components/ui/Input/FamilyName';
 
 export const BasicInfomationForm = () => {
   const {
@@ -33,20 +34,7 @@ export const BasicInfomationForm = () => {
   return (
     <>
       <div className='flex flex-row gap-x-4'>
-        <FormField
-          control={control}
-          name='familyName'
-          render={({ field }) => (
-            <FormItem className='flex-1'>
-              <FormLabel>名字</FormLabel>
-              <FormControl>
-                <Input placeholder='山田' {...field} />
-              </FormControl>
-              <FormDescription>ここは説明箇所です.</FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        <FamilyName control={control} />
 
         <FormField
           control={control}

--- a/src/screens/ApplyScreen/schemas/index.ts
+++ b/src/screens/ApplyScreen/schemas/index.ts
@@ -1,14 +1,11 @@
 import { z } from 'zod';
 
 import { calcAcademicPeriodDate } from '@/utils/days';
+import { generateFamilyNameValidation } from '@/components/ui/Input/FamilyName';
 
 const createBasicInformationSchema = (minAge: number = 0) =>
   z.object({
-    familyName: z
-      .string()
-      // NOTE: min(1)で、必須項目を表現する
-      .min(1, { message: '名字を入力してください' })
-      .max(50, { message: '50文字以内で入力してください' }),
+    ...generateFamilyNameValidation(),
     firstName: z
       .string()
       .min(1, { message: '名前を入力してください' })


### PR DESCRIPTION
## Conclusion
- コンポーネントと項目ごとのスキーマは、1ファイル内で定義する
  - co-locationで
- デザインシステムとして切り出す時はデザインシステムがどこまでの依存を持つかによるが、同階層にコンポーネントとスキーマファイルは分けてもいい
- 使用する側は、定義したschemaを呼ぶのではなく、generateの関数をexportしているのでそちらを呼び、スプレッド演算子で展開する
  - これは画面によってValidationSchemaの内容が変わる時に吸収できるように関数化しておく
  - 必要がない項目もあると思うがここは統一させておく
