### PR TITLE
生年月日のカスタムエラーの出力方法の修正

### DIFF
--- a/src/components/ui/Select/Birthday/index.tsx
+++ b/src/components/ui/Select/Birthday/index.tsx
@@ -4,7 +4,13 @@ import { PartialFormValidation } from '@/libs/zod-utils';
 import { useFormContext } from 'react-hook-form';
 import { calcAcademicPeriodDate } from '@/utils/days';
 
-import { FormControl, FormField, FormItem, FormLabel } from '@/components/ui/Form/form';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/Form/form';
 import { Select, SelectTrigger, SelectValue } from '@/components/ui/Select/select';
 import { Year } from '@/components/ui/Select/Birthday/Year';
 import { Month } from '@/components/ui/Select/Birthday/Month';
@@ -39,6 +45,7 @@ const birthdayDefaultValidation: PartialFormValidation<BirthdaySchemaType> = {
       },
       {
         message: '生年月日をすべて選択してください',
+        path: [''],
       },
     ),
 };
@@ -70,6 +77,7 @@ const generateBirthdayValidation = (minAge: number = 0) => {
           },
           {
             message: '応募条件を満たす年齢に達していません',
+            path: [''],
           },
         ),
       };
@@ -89,63 +97,78 @@ const Birthday: FC<Props> = ({
   selectedYear,
   selectedMonth,
 }: Props) => {
-  const { control } = useFormContext<BirthdaySchemaType>();
+  const {
+    control,
+    formState: { errors },
+  } = useFormContext<BirthdaySchemaType>();
 
   return (
     <>
-      <FormField
-        control={control}
-        name='birthday.year'
-        render={({ field: { ref, onChange, ...restField } }) => (
-          <FormItem>
-            <FormLabel>西暦</FormLabel>
-            <Select {...restField} onValueChange={handleYearChange}>
-              <FormControl>
-                <SelectTrigger ref={ref} className='w-[180px]'>
-                  <SelectValue placeholder='西暦' />
-                </SelectTrigger>
-              </FormControl>
-              <Year />
-            </Select>
-          </FormItem>
-        )}
-      />
+      <div className='flex flex-row gap-x-4'>
+        <FormField
+          control={control}
+          name='birthday.year'
+          render={({ field: { ref, onChange, ...restField } }) => (
+            <FormItem>
+              <FormLabel>西暦</FormLabel>
+              <Select {...restField} onValueChange={handleYearChange}>
+                <FormControl>
+                  <SelectTrigger ref={ref} className='w-[180px]'>
+                    <SelectValue placeholder='西暦' />
+                  </SelectTrigger>
+                </FormControl>
+                <Year />
+              </Select>
+            </FormItem>
+          )}
+        />
 
-      <FormField
-        control={control}
-        name='birthday.month'
-        render={({ field: { ref, onChange, ...restField } }) => (
-          <FormItem>
-            <FormLabel>月</FormLabel>
-            <Select {...restField} onValueChange={handleMonthChange}>
-              <FormControl>
-                <SelectTrigger ref={ref} className='w-[180px]'>
-                  <SelectValue placeholder='月' />
-                </SelectTrigger>
-              </FormControl>
-              <Month />
-            </Select>
-          </FormItem>
-        )}
-      />
+        <FormField
+          control={control}
+          name='birthday.month'
+          render={({ field: { ref, onChange, ...restField } }) => (
+            <FormItem>
+              <FormLabel>月</FormLabel>
+              <Select {...restField} onValueChange={handleMonthChange}>
+                <FormControl>
+                  <SelectTrigger ref={ref} className='w-[180px]'>
+                    <SelectValue placeholder='月' />
+                  </SelectTrigger>
+                </FormControl>
+                <Month />
+              </Select>
+            </FormItem>
+          )}
+        />
 
-      <FormField
-        control={control}
-        name='birthday.day'
-        render={({ field: { ref, onChange, ...restField } }) => (
-          <FormItem>
-            <FormLabel>日</FormLabel>
-            <Select {...restField} onValueChange={handleDayChange}>
-              <FormControl>
-                <SelectTrigger ref={ref} className='w-[180px]'>
-                  <SelectValue placeholder='日' />
-                </SelectTrigger>
-              </FormControl>
-              <Day year={selectedYear} month={selectedMonth} />
-            </Select>
-          </FormItem>
-        )}
-      />
+        <FormField
+          control={control}
+          name='birthday.day'
+          render={({ field: { ref, onChange, ...restField } }) => (
+            <FormItem>
+              <FormLabel>日</FormLabel>
+              <Select {...restField} onValueChange={handleDayChange}>
+                <FormControl>
+                  <SelectTrigger ref={ref} className='w-[180px]'>
+                    <SelectValue placeholder='日' />
+                  </SelectTrigger>
+                </FormControl>
+                <Day year={selectedYear} month={selectedMonth} />
+              </Select>
+            </FormItem>
+          )}
+        />
+      </div>
+
+      {errors.birthday?.year?.message ? (
+        <FormField name='birthday.year' render={() => <FormMessage />} />
+      ) : errors.birthday?.month?.message ? (
+        <FormField name='birthday.month' render={() => <FormMessage />} />
+      ) : errors.birthday?.day?.message ? (
+        <FormField name='birthday.day' render={() => <FormMessage />} />
+      ) : (
+        <FormField name='birthday' render={() => <FormMessage />} />
+      )}
     </>
   );
 };

--- a/src/screens/ApplyScreen/ApplyForm/ApplyInfomationForm/index.tsx
+++ b/src/screens/ApplyScreen/ApplyForm/ApplyInfomationForm/index.tsx
@@ -37,13 +37,11 @@ export const ApplyInfomationForm = ({ qualifications }: Props) => {
       </div>
 
       <div>
-        <div>
-          <PreferredDatetime
-            handlePreferredDateChange={handlePreferredDateChange}
-            handlePreferredTimeHourChange={handlePreferredTimeHourChange}
-            handlePreferredTimeMinuteChange={handlePreferredTimeMinuteChange}
-          />
-        </div>
+        <PreferredDatetime
+          handlePreferredDateChange={handlePreferredDateChange}
+          handlePreferredTimeHourChange={handlePreferredTimeHourChange}
+          handlePreferredTimeMinuteChange={handlePreferredTimeMinuteChange}
+        />
       </div>
     </>
   );

--- a/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/index.tsx
+++ b/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/index.tsx
@@ -20,7 +20,6 @@ import { EmploymentStatus } from '@/components/ui/RadioGroup/EmploymentStatus';
 
 export const BasicInfomationForm = () => {
   const {
-    errors,
     selectedYear,
     selectedMonth,
     selectedPrefecture,
@@ -45,34 +44,13 @@ export const BasicInfomationForm = () => {
       </div>
 
       <div>
-        <div className='flex flex-row gap-x-4'>
-          <Birthday
-            handleYearChange={handleYearChange}
-            handleMonthChange={handleMonthChange}
-            handleDayChange={handleDayChange}
-            selectedYear={selectedYear}
-            selectedMonth={selectedMonth}
-          />
-        </div>
-
-        {errors.birthday?.year?.message ? (
-          <FormField name='birthday.year' render={() => <FormMessage />} />
-        ) : errors.birthday?.month?.message ? (
-          <FormField name='birthday.month' render={() => <FormMessage />} />
-        ) : errors.birthday?.day?.message ? (
-          <FormField name='birthday.day' render={() => <FormMessage />} />
-        ) : errors.birthday?.message ? (
-          <FormField name='birthday' render={() => <FormMessage />} />
-        ) : (
-          //
-          // TODO: グローバルエラーの取り扱いが、onChange系とonSubmitで二重管理になっているのをなんとかしたい
-          //       とりあえずは、rootも指定することで最悪の事態は避ける.
-          // @see: https://github.com/react-hook-form/resolvers/issues/561
-          //
-          errors.birthday?.root?.message && (
-            <FormField name='birthday.root' render={() => <FormMessage />} />
-          )
-        )}
+        <Birthday
+          handleYearChange={handleYearChange}
+          handleMonthChange={handleMonthChange}
+          handleDayChange={handleDayChange}
+          selectedYear={selectedYear}
+          selectedMonth={selectedMonth}
+        />
       </div>
 
       <div>

--- a/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/useBasicInformationForm.ts
+++ b/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/useBasicInformationForm.ts
@@ -4,12 +4,7 @@ import { getDaysInMonth } from '@/utils/days';
 import { getZipcodeOrList } from '@/__generated_REST__/zipcloud/zipcloud';
 
 export const useBasicInformaionForm = () => {
-  const {
-    watch,
-    setValue,
-    trigger,
-    formState: { errors },
-  } = useFormContext<BasicInformationSchemaType>();
+  const { watch, setValue, trigger } = useFormContext<BasicInformationSchemaType>();
 
   const selectedYear = watch('birthday.year');
   const selectedMonth = watch('birthday.month');
@@ -114,8 +109,6 @@ export const useBasicInformaionForm = () => {
   };
 
   return {
-    errors,
-
     selectedYear,
     selectedMonth,
     selectedPrefecture,


### PR DESCRIPTION
## Conclusion
- refineのpathに `['']` を設定すると、onSubmitでもonChange系でもrootには入らず、親のキーになる（ `birthday` ）
- rootを愚直につけるか、pathを何かしら必ず設定するかの二択っぽいが、後者にした