### PR TITLE
郵便番号のハイフンありなしの許容とそれに伴うロジック変更対応

### DIFF
--- a/src/components/ui/Input/PostalCode/index.tsx
+++ b/src/components/ui/Input/PostalCode/index.tsx
@@ -20,8 +20,8 @@ type PostalCodeSchemaType = {
 const postalCodeDefaultValidation: PartialFormValidation<PostalCodeSchemaType> = {
   postalCode: z
     .string()
-    .max(7, { message: '正しい郵便番号を入力してください' })
-    .regex(/^\d{7}$/, { message: '正しい郵便番号を入力してください' })
+    .max(8, { message: '正しい郵便番号を入力してください' })
+    .regex(/^(?:\d{7}|\d{3}-\d{4})$/, { message: '正しい郵便番号を入力してください' })
     //
     // TODO: 必須ではないが、入力するならバリデーションを発火させたい場合の書き方？
     // @see: https://zenn.dev/kaz_z/articles/how-to-use-zod#%E5%85%A5%E5%8A%9B%E3%81%99%E3%82%8B%E5%A0%B4%E5%90%88%E3%81%AF%E3%83%90%E3%83%AA%E3%83%87%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%8C%E5%BF%85%E8%A6%81%E3%81%A0%E3%81%91%E3%81%A9%E3%80%81%E7%A9%BA%E3%81%AE%E3%81%BE%E3%81%BE%E3%81%A7%E3%82%82%E3%81%84%E3%81%84

--- a/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/useBasicInformationForm.ts
+++ b/src/screens/ApplyScreen/ApplyForm/BasicInformationForm/useBasicInformationForm.ts
@@ -73,7 +73,13 @@ export const useBasicInformaionForm = () => {
     setValue('postalCode', value);
     trigger('postalCode');
 
-    if (value.length === 7) {
+    //
+    // NOTE: ハイフンを許容したUIのため、Stateを変更せず、
+    //       ロジックで対応する
+    //
+    const sanitizedPostalCode = value.replace(/-/g, '');
+
+    if (sanitizedPostalCode.length === 7) {
       //
       // TODO: 本来、refineで定義する様な内容とフォームへ反映するという2つの機能が包括されている
       //       入力された郵便番号が正しいかのチェックとそれを踏まえて都道府県、市区町村、町名・番地への反映

--- a/src/screens/ApplyScreen/ApplyForm/index.tsx
+++ b/src/screens/ApplyScreen/ApplyForm/index.tsx
@@ -99,7 +99,11 @@ export const ApplyForm = ({ id }: Props) => {
   });
 
   const onSubmit: SubmitHandler<ApplyFormSchemaType> = (data) => {
-    window.alert(JSON.stringify(data));
+    window.alert(`変換前: ${JSON.stringify(data)}`);
+
+    data.postalCode = data.postalCode.replace(/-/g, '');
+
+    window.alert(`変換後: ${JSON.stringify(data)}`);
   };
 
   console.log(forms.formState.errors);


### PR DESCRIPTION
## Conclusion
- ハイフン有無は問わない
- stateの中身は書き換えない＝ユーザ入力値保持
- handlerロジック、onSubmitロジック、バリデーションスキーマの拡張