### PR TITLE
電話番号のハイフン許容とそれに伴ったロジック変更

### DIFF
--- a/src/components/ui/Input/Tel/index.tsx
+++ b/src/components/ui/Input/Tel/index.tsx
@@ -21,7 +21,10 @@ const telDefaultValidation: PartialFormValidation<TelSchemaType> = {
   tel: z
     .string()
     .min(1, { message: '電話番号を入力してください' })
-    .regex(/^\d{10,11}$/, { message: '正しい電話番号を入力してください' }),
+    .max(13, { message: '正しい電話番号を入力してください' })
+    .regex(/^(?:\d{2,5}-?\d{1,4}-?\d{4}|\d{10,11})$/, {
+      message: '正しい電話番号を入力してください',
+    }),
 };
 
 const generateTelValidation = () => {

--- a/src/screens/ApplyScreen/ApplyForm/index.tsx
+++ b/src/screens/ApplyScreen/ApplyForm/index.tsx
@@ -102,6 +102,7 @@ export const ApplyForm = ({ id }: Props) => {
     window.alert(`変換前: ${JSON.stringify(data)}`);
 
     data.postalCode = data.postalCode.replace(/-/g, '');
+    data.tel = data.tel.replace(/-/g, '');
 
     window.alert(`変換後: ${JSON.stringify(data)}`);
   };


### PR DESCRIPTION
## Conclusion
- 電話番号は、携帯電話と固定電話の両方をカバーする
  - 03-1234-5678、0312345678、
  - 0867-72-1234、043-278-0987、
  - 090-1234-5678、09012345678
  - あたりを全部カバーしている